### PR TITLE
feat(ui): display per-file symbol counts and add AllSeen coverage state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ambits"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ambits"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "command line utility for symbols used by Claude agents"
 repository = "https://github.com/joshLong145/claude-marker"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It's a real-time TUI that watches Claude Code session logs and paints every func
 - **Depth-aware coverage** — Every symbol is color-coded by read depth: unseen, name-only, overview, signature, or full body
 - **Staleness detection** — When source files change on disk, previously-read symbols are automatically marked stale so you know what needs a re-read
 - **Coverage reports** — Generate tabular per-file coverage summaries for CI or quick audits
+- **Per-file coverage counts** — Each file shows a `seen/total` symbol count so you can tell at a glance how much of it the agent has inspected
 - **Sortable tree view** — Toggle between alphabetical and coverage-grouped ordering to surface partially-covered files first
 - **Multiple parsing backends** — Tree-sitter for fast local parsing, or [Serena MCP](https://github.com/oraios/serena) for richer LSP-based symbol data across more languages
 
@@ -154,6 +155,7 @@ Claude will run the appropriate `ambits` commands and interpret the coverage res
 
 | Color | Meaning |
 |---|---|
-| White | No symbols read at full body depth |
-| Amber | Partially covered (some symbols read fully) |
+| White | No symbols seen |
+| Amber | Partially covered (some symbols seen) |
+| Yellow-green | All seen (every symbol seen, but not all at full body depth) |
 | Green | Fully covered (all symbols read at full body depth) |

--- a/src/ui/activity.rs
+++ b/src/ui/activity.rs
@@ -6,6 +6,8 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 
 use ambits::app::{App, FocusPanel};
 
+use super::colors;
+
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let border_style = if app.focus == FocusPanel::Activity {
         Style::default().fg(Color::Cyan)
@@ -35,7 +37,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
             Line::from(vec![
                 Span::styled(
                     format!(" [{}] ", agent_short),
-                    Style::default().fg(Color::Rgb(120, 120, 180)),
+                    Style::default().fg(colors::ACCENT_MUTED),
                 ),
                 Span::styled(
                     &event.description,
@@ -62,4 +64,57 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     };
 
     f.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use ambits::ingest::AgentToolCall;
+    use ambits::symbols::{ProjectTree, FileSymbols};
+    use ambits::tracking::ReadDepth;
+
+    fn test_app() -> App {
+        let tree = ProjectTree {
+            root: PathBuf::from("/test"),
+            files: vec![
+                FileSymbols { file_path: "mock/a.rs".into(), symbols: Vec::new(), total_lines: 10 },
+            ],
+        };
+        App::new(tree, PathBuf::from("/test"), None)
+    }
+
+    /// Find the foreground color of the first cell in `row` that contains part of `text`.
+    fn fg_color_of(backend: &TestBackend, row: u16, text: &str) -> Option<Color> {
+        let buf = backend.buffer();
+        let row_str: String = (0..buf.area.width)
+            .map(|x| buf[(x, row)].symbol().to_string())
+            .collect::<String>();
+        let col = row_str.find(text)? as u16;
+        Some(buf[(col, row)].fg)
+    }
+
+    #[test]
+    fn render_with_activity_uses_accent_color() {
+        let mut app = test_app();
+        app.activity.push(AgentToolCall {
+            agent_id: "agent-abc123".into(),
+            tool_name: "Read".into(),
+            file_path: Some(PathBuf::from("mock/a.rs")),
+            read_depth: ReadDepth::FullBody,
+            description: "Read a.rs".into(),
+            timestamp_str: "2025-01-01T00:00:00Z".into(),
+            target_symbol: None,
+            target_lines: None,
+        });
+
+        let backend = TestBackend::new(60, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        let color = fg_color_of(terminal.backend(), 1, "agent-ab").unwrap();
+        assert_eq!(color, colors::ACCENT_MUTED);
+    }
 }

--- a/src/ui/colors.rs
+++ b/src/ui/colors.rs
@@ -1,0 +1,28 @@
+//! Shared color palette for the TUI.
+
+use ratatui::style::Color;
+
+// ── Read-depth colors (symbol level) ────────────────────────────────
+pub const DEPTH_UNSEEN: Color = Color::Rgb(100, 100, 100);
+pub const DEPTH_NAME_ONLY: Color = Color::Rgb(160, 160, 160);
+pub const DEPTH_OVERVIEW: Color = Color::Rgb(120, 160, 220);
+pub const DEPTH_SIGNATURE: Color = Color::Rgb(80, 140, 255);
+pub const DEPTH_FULL_BODY: Color = Color::Rgb(80, 220, 120);
+pub const DEPTH_STALE: Color = Color::Rgb(230, 160, 60);
+
+// ── File coverage colors (file header level) ────────────────────────
+pub const FILE_FULLY_COVERED: Color = Color::Rgb(80, 220, 120);
+pub const FILE_ALL_SEEN: Color = Color::Rgb(180, 220, 80);
+pub const FILE_PARTIALLY_COVERED: Color = Color::Rgb(255, 180, 50);
+pub const FILE_NOT_COVERED: Color = Color::White;
+
+// ── Coverage percentage gradient ────────────────────────────────────
+pub const PCT_LOW: Color = Color::Rgb(180, 60, 60);
+pub const PCT_MID_LOW: Color = Color::Rgb(230, 160, 60);
+pub const PCT_MID_HIGH: Color = Color::Rgb(200, 200, 80);
+pub const PCT_HIGH: Color = Color::Rgb(80, 220, 120);
+
+// ── Accent / chrome ─────────────────────────────────────────────────
+pub const ACCENT_MUTED: Color = Color::Rgb(120, 120, 180);
+pub const HIGHLIGHT_BG: Color = Color::Rgb(60, 55, 50);
+pub const HIGHLIGHT_FG: Color = Color::Rgb(255, 220, 150);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod colors;
 pub mod tree_view;
 pub mod stats;
 pub mod activity;

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -7,6 +7,8 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 use ambits::app::{App, FocusPanel};
 use ambits::tracking::ReadDepth;
 
+use super::colors;
+
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let border_style = if app.focus == FocusPanel::Stats {
         Style::default().fg(Color::Cyan)
@@ -47,15 +49,15 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
             ),
         ]),
         Line::from(""),
-        stat_line("  Full Body", count_for(ReadDepth::FullBody), Color::Rgb(80, 220, 120)),
-        stat_line("  Signature", count_for(ReadDepth::Signature), Color::Rgb(80, 140, 255)),
-        stat_line("  Overview ", count_for(ReadDepth::Overview), Color::Rgb(120, 160, 220)),
-        stat_line("  Name Only", count_for(ReadDepth::NameOnly), Color::Rgb(160, 160, 160)),
-        stat_line("  Stale    ", count_for(ReadDepth::Stale), Color::Rgb(230, 160, 60)),
+        stat_line("  Full Body", count_for(ReadDepth::FullBody), colors::DEPTH_FULL_BODY),
+        stat_line("  Signature", count_for(ReadDepth::Signature), colors::DEPTH_SIGNATURE),
+        stat_line("  Overview ", count_for(ReadDepth::Overview), colors::DEPTH_OVERVIEW),
+        stat_line("  Name Only", count_for(ReadDepth::NameOnly), colors::DEPTH_NAME_ONLY),
+        stat_line("  Stale    ", count_for(ReadDepth::Stale), colors::DEPTH_STALE),
         stat_line(
             "  Unseen   ",
             total.saturating_sub(seen),
-            Color::Rgb(100, 100, 100),
+            colors::DEPTH_UNSEEN,
         ),
         Line::from(""),
         Line::from(vec![
@@ -77,7 +79,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         let short = if sid.len() > 12 { &sid[..12] } else { sid };
         lines.push(Line::from(vec![
             Span::raw("  Session: "),
-            Span::styled(short, Style::default().fg(Color::Rgb(120, 120, 180))),
+            Span::styled(short, Style::default().fg(colors::ACCENT_MUTED)),
         ]));
     }
 
@@ -108,7 +110,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
             let color = if is_selected {
                 Color::Yellow
             } else {
-                Color::Rgb(120, 120, 180)
+                colors::ACCENT_MUTED
             };
             lines.push(Line::from(vec![
                 Span::styled(prefix, Style::default().fg(Color::DarkGray)),
@@ -141,9 +143,123 @@ fn short_id(id: &str) -> String {
 
 fn coverage_color(pct: u32) -> Color {
     match pct {
-        0..=20 => Color::Rgb(180, 60, 60),
-        21..=50 => Color::Rgb(230, 160, 60),
-        51..=80 => Color::Rgb(200, 200, 80),
-        _ => Color::Rgb(80, 220, 120),
+        0..=20 => colors::PCT_LOW,
+        21..=50 => colors::PCT_MID_LOW,
+        51..=80 => colors::PCT_MID_HIGH,
+        _ => colors::PCT_HIGH,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use ambits::symbols::{ProjectTree, FileSymbols, SymbolCategory, SymbolNode};
+
+    fn sym(id: &str, name: &str) -> SymbolNode {
+        let hash = ambits::symbols::merkle::content_hash(name);
+        SymbolNode {
+            id: id.into(), name: name.into(), category: SymbolCategory::Function,
+            label: "fn".into(), file_path: PathBuf::new(),
+            byte_range: 0..100, line_range: 1..10, content_hash: hash,
+            merkle_hash: hash, children: Vec::new(), estimated_tokens: 30,
+        }
+    }
+
+    fn test_app() -> App {
+        let tree = ProjectTree {
+            root: PathBuf::from("/test"),
+            files: vec![
+                FileSymbols { file_path: "mock/a.rs".into(), symbols: vec![sym("a1", "alpha")], total_lines: 50 },
+            ],
+        };
+        App::new(tree, PathBuf::from("/test"), None)
+    }
+
+    /// Find the foreground color of the first cell matching `text` in the entire buffer.
+    fn fg_color_of(backend: &TestBackend, text: &str) -> Option<Color> {
+        let buf = backend.buffer();
+        for y in 0..buf.area.height {
+            let row_str: String = (0..buf.area.width)
+                .map(|x| buf[(x, y)].symbol().to_string())
+                .collect();
+            if let Some(col) = row_str.find(text) {
+                return Some(buf[(col as u16, y)].fg);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn coverage_color_gradient() {
+        assert_eq!(coverage_color(0), colors::PCT_LOW);
+        assert_eq!(coverage_color(20), colors::PCT_LOW);
+        assert_eq!(coverage_color(21), colors::PCT_MID_LOW);
+        assert_eq!(coverage_color(50), colors::PCT_MID_LOW);
+        assert_eq!(coverage_color(51), colors::PCT_MID_HIGH);
+        assert_eq!(coverage_color(80), colors::PCT_MID_HIGH);
+        assert_eq!(coverage_color(81), colors::PCT_HIGH);
+        assert_eq!(coverage_color(100), colors::PCT_HIGH);
+    }
+
+    #[test]
+    fn short_id_truncates() {
+        assert_eq!(short_id("abcdefghijklmnop"), "abcdefghijkl");
+        assert_eq!(short_id("short"), "short");
+        assert_eq!(short_id("exactly12chr"), "exactly12chr");
+    }
+
+    #[test]
+    fn stat_line_format() {
+        let line = stat_line("  Full Body", 42, colors::DEPTH_FULL_BODY);
+        let spans: Vec<_> = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(spans[0], "  Full Body: ");
+        assert_eq!(spans[1], "   42");
+    }
+
+    #[test]
+    fn render_shows_zero_coverage() {
+        let app = test_app();
+        let backend = TestBackend::new(40, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        // The percentage is the only bold-styled content; find it by modifier.
+        let buf = terminal.backend().buffer();
+        let bold_cell = (0..buf.area.height)
+            .flat_map(|y| (0..buf.area.width).map(move |x| &buf[(x, y)]))
+            .find(|cell| cell.modifier.contains(Modifier::BOLD))
+            .expect("bold percentage cell not found");
+        assert_eq!(bold_cell.fg, colors::PCT_LOW);
+    }
+
+    #[test]
+    fn render_shows_full_coverage() {
+        let mut app = test_app();
+        app.ledger.record("a1".into(), ReadDepth::FullBody, [0; 32], "ag".into(), 10);
+        app.rebuild_tree_rows();
+
+        let backend = TestBackend::new(40, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        let color = fg_color_of(terminal.backend(), "100%").unwrap();
+        assert_eq!(color, colors::PCT_HIGH);
+    }
+
+    #[test]
+    fn render_with_session_and_agents() {
+        let mut app = test_app();
+        app.session_id = Some("abcdef123456789".into());
+        app.agents_seen.push("agent-abc123456789".into());
+
+        let backend = TestBackend::new(40, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        let color = fg_color_of(terminal.backend(), "abcdef123456").unwrap();
+        assert_eq!(color, colors::ACCENT_MUTED);
     }
 }

--- a/src/ui/tree_view.rs
+++ b/src/ui/tree_view.rs
@@ -7,6 +7,8 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
 use ambits::app::{App, FileCoverageStatus, FocusPanel};
 use ambits::tracking::ReadDepth;
 
+use super::colors;
+
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let border_style = if app.focus == FocusPanel::Tree {
         Style::default().fg(Color::Cyan)
@@ -40,15 +42,17 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
             ];
 
             if row.is_file {
-                let file_color = match row.coverage_status {
-                    Some(FileCoverageStatus::FullyCovered) => Color::Rgb(80, 220, 120),
-                    Some(FileCoverageStatus::PartiallyCovered) => Color::Rgb(255, 180, 50),
-                    _ => Color::White,
-                };
+                let file_color = file_coverage_color(row.coverage_status);
                 spans.push(Span::styled(
                     &row.display_name,
                     Style::default().fg(file_color).add_modifier(Modifier::BOLD),
                 ));
+                if row.file_coverage_total > 0 {
+                    spans.push(Span::styled(
+                        format!("  {}/{}", row.file_coverage_seen, row.file_coverage_total),
+                        Style::default().fg(file_color),
+                    ));
+                }
                 spans.push(Span::styled(
                     format!("  ({})", row.line_range),
                     Style::default().fg(Color::DarkGray),
@@ -76,8 +80,8 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         .block(block)
         .highlight_style(
             Style::default()
-                .bg(Color::Rgb(60, 55, 50))
-                .fg(Color::Rgb(255, 220, 150))
+                .bg(colors::HIGHLIGHT_BG)
+                .fg(colors::HIGHLIGHT_FG)
                 .add_modifier(Modifier::BOLD),
         );
 
@@ -86,11 +90,153 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
 
 fn depth_color(depth: ReadDepth) -> Color {
     match depth {
-        ReadDepth::Unseen => Color::Rgb(100, 100, 100),
-        ReadDepth::NameOnly => Color::Rgb(160, 160, 160),
-        ReadDepth::Overview => Color::Rgb(120, 160, 220),
-        ReadDepth::Signature => Color::Rgb(80, 140, 255),
-        ReadDepth::FullBody => Color::Rgb(80, 220, 120),
-        ReadDepth::Stale => Color::Rgb(230, 160, 60),
+        ReadDepth::Unseen => colors::DEPTH_UNSEEN,
+        ReadDepth::NameOnly => colors::DEPTH_NAME_ONLY,
+        ReadDepth::Overview => colors::DEPTH_OVERVIEW,
+        ReadDepth::Signature => colors::DEPTH_SIGNATURE,
+        ReadDepth::FullBody => colors::DEPTH_FULL_BODY,
+        ReadDepth::Stale => colors::DEPTH_STALE,
+    }
+}
+
+fn file_coverage_color(status: Option<FileCoverageStatus>) -> Color {
+    match status {
+        Some(FileCoverageStatus::FullyCovered) => colors::FILE_FULLY_COVERED,
+        Some(FileCoverageStatus::AllSeen) => colors::FILE_ALL_SEEN,
+        Some(FileCoverageStatus::PartiallyCovered) => colors::FILE_PARTIALLY_COVERED,
+        _ => colors::FILE_NOT_COVERED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use ambits::symbols::{ProjectTree, FileSymbols, SymbolCategory, SymbolNode};
+
+    fn sym(id: &str, name: &str) -> SymbolNode {
+        let hash = ambits::symbols::merkle::content_hash(name);
+        SymbolNode {
+            id: id.into(), name: name.into(), category: SymbolCategory::Function,
+            label: "fn".into(), file_path: PathBuf::new(),
+            byte_range: 0..100, line_range: 1..10, content_hash: hash,
+            merkle_hash: hash, children: Vec::new(), estimated_tokens: 30,
+        }
+    }
+
+    fn test_app() -> App {
+        let tree = ProjectTree {
+            root: PathBuf::from("/test"),
+            files: vec![
+                FileSymbols { file_path: "mock/a.rs".into(), symbols: vec![sym("a1", "alpha"), sym("a2", "beta")], total_lines: 50 },
+                FileSymbols { file_path: "mock/b.rs".into(), symbols: vec![sym("b1", "gamma")], total_lines: 30 },
+            ],
+        };
+        App::new(tree, PathBuf::from("/test"), None)
+    }
+
+    /// Find the foreground color of the first cell in `row` that contains part of `text`.
+    fn fg_color_of(backend: &TestBackend, row: u16, text: &str) -> Option<Color> {
+        let buf = backend.buffer();
+        let row_str: String = (0..buf.area.width)
+            .map(|x| buf[(x, row)].symbol().to_string())
+            .collect::<String>();
+        let col = row_str.find(text)? as u16;
+        Some(buf[(col, row)].fg)
+    }
+
+    #[test]
+    fn file_coverage_color_variants() {
+        assert_eq!(file_coverage_color(Some(FileCoverageStatus::FullyCovered)), colors::FILE_FULLY_COVERED);
+        assert_eq!(file_coverage_color(Some(FileCoverageStatus::AllSeen)), colors::FILE_ALL_SEEN);
+        assert_eq!(file_coverage_color(Some(FileCoverageStatus::PartiallyCovered)), colors::FILE_PARTIALLY_COVERED);
+        assert_eq!(file_coverage_color(Some(FileCoverageStatus::NotCovered)), colors::FILE_NOT_COVERED);
+        assert_eq!(file_coverage_color(None), colors::FILE_NOT_COVERED);
+    }
+
+    #[test]
+    fn depth_color_variants() {
+        assert_eq!(depth_color(ReadDepth::Unseen), colors::DEPTH_UNSEEN);
+        assert_eq!(depth_color(ReadDepth::NameOnly), colors::DEPTH_NAME_ONLY);
+        assert_eq!(depth_color(ReadDepth::Overview), colors::DEPTH_OVERVIEW);
+        assert_eq!(depth_color(ReadDepth::Signature), colors::DEPTH_SIGNATURE);
+        assert_eq!(depth_color(ReadDepth::FullBody), colors::DEPTH_FULL_BODY);
+        assert_eq!(depth_color(ReadDepth::Stale), colors::DEPTH_STALE);
+    }
+
+    #[test]
+    fn render_uncovered_files_are_white() {
+        let mut app = test_app();
+        // Select row 2 so row 1 (a.rs) isn't highlighted.
+        app.selected_index = 1;
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        let color = fg_color_of(terminal.backend(), 1, "mock/a.rs").unwrap();
+        assert_eq!(color, colors::FILE_NOT_COVERED);
+    }
+
+    #[test]
+    fn render_fully_covered_file_is_green() {
+        let mut app = test_app();
+        app.selected_index = 1;
+        app.ledger.record("a1".into(), ReadDepth::FullBody, [0; 32], "ag".into(), 10);
+        app.ledger.record("a2".into(), ReadDepth::FullBody, [0; 32], "ag".into(), 10);
+        app.rebuild_tree_rows();
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        let color = fg_color_of(terminal.backend(), 1, "mock/a.rs").unwrap();
+        assert_eq!(color, colors::FILE_FULLY_COVERED);
+    }
+
+    #[test]
+    fn render_all_seen_file_is_yellow_green() {
+        let mut app = test_app();
+        app.ledger.record("b1".into(), ReadDepth::NameOnly, [0; 32], "ag".into(), 10);
+        app.rebuild_tree_rows();
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        let color = fg_color_of(terminal.backend(), 2, "mock/b.rs").unwrap();
+        assert_eq!(color, colors::FILE_ALL_SEEN);
+    }
+
+    #[test]
+    fn render_partially_covered_file_is_amber() {
+        let mut app = test_app();
+        app.selected_index = 1;
+        app.ledger.record("a1".into(), ReadDepth::NameOnly, [0; 32], "ag".into(), 10);
+        app.rebuild_tree_rows();
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        let color = fg_color_of(terminal.backend(), 1, "mock/a.rs").unwrap();
+        assert_eq!(color, colors::FILE_PARTIALLY_COVERED);
+    }
+
+    #[test]
+    fn render_expanded_symbol_has_depth_color() {
+        let mut app = test_app();
+        app.selected_index = 2;
+        app.collapsed.remove("mock/a.rs");
+        app.ledger.record("a1".into(), ReadDepth::FullBody, [0; 32], "ag".into(), 10);
+        app.rebuild_tree_rows();
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+
+        let color = fg_color_of(terminal.backend(), 2, "alpha").unwrap();
+        assert_eq!(color, colors::DEPTH_FULL_BODY);
     }
 }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -4,7 +4,8 @@ use crate::ingest::AgentToolCall;
 use crate::symbols::{FileSymbols, ProjectTree, SymbolCategory, SymbolNode};
 use crate::tracking::ReadDepth;
 
-/// Create a minimal SymbolNode with sensible defaults.
+/// Create a mock SymbolNode for testing.
+/// The `file_path` is left empty; `file()` sets it to match the parent `FileSymbols`.
 pub fn sym(id: &str, name: &str) -> SymbolNode {
     let hash = crate::symbols::merkle::content_hash(name);
     SymbolNode {
@@ -12,7 +13,7 @@ pub fn sym(id: &str, name: &str) -> SymbolNode {
         name: name.to_string(),
         category: SymbolCategory::Function,
         label: "fn".to_string(),
-        file_path: PathBuf::from("test.rs"),
+        file_path: PathBuf::new(),
         byte_range: 0..100,
         line_range: 1..10,
         content_hash: hash,
@@ -36,10 +37,18 @@ pub fn sym_with_lines(id: &str, name: &str, start: usize, end: usize) -> SymbolN
     s
 }
 
-/// Create a FileSymbols entry.
+/// Create a FileSymbols entry, setting each symbol's `file_path` to match.
 pub fn file(path: &str, symbols: Vec<SymbolNode>) -> FileSymbols {
+    let file_path = PathBuf::from(path);
+    let symbols = symbols
+        .into_iter()
+        .map(|mut s| {
+            s.file_path = file_path.clone();
+            s
+        })
+        .collect();
     FileSymbols {
-        file_path: PathBuf::from(path),
+        file_path,
         symbols,
         total_lines: 100,
     }


### PR DESCRIPTION
Show seen/total symbol counts next to each file name in the tree view so users can tell at a glance how much of a file the agent has read.

Add a fourth file coverage state to fix a confusing mismatch where files showing e.g. 5/5 could still appear amber - the displayed count used seen symbols while the color was based on full-body count only.

File header color states are now:
- White: no symbols seen
- Amber: partially covered (some symbols seen)
- Yellow-green (new): all seen (every symbol seen, not all at FullBody)
- Green: fully covered (all symbols read at full body depth)

Updates FileCoverageStatus enum, coverage_status_from_counts (now accepts seen param), tree view color mapping, tests, and README.