### PR TITLE
feat(coverage): add json formatting to coverage output

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ ambits --project <path>
 | `--agent`, `-a` | Filter coverage to a specific agent ID (supports prefix matching) |
 | `--dump` | Print symbol tree to stdout and exit |
 | `--coverage` | Print coverage report to stdout and exit |
+| `--format` | Coverage output format: `table` (default) or `json` |
 | `--serena` | Use Serena's LSP symbol cache instead of tree-sitter |
 | `--log-dir` | Path to Claude Code log directory (auto-derived) |
 | `--log-output` | Output directory for event logs |
@@ -102,6 +103,12 @@ TOTAL                                         214     182     175     85%     82
 
 - **Seen%**: Symbols the agent has any awareness of (name, overview, signature, or full body)
 - **Full%**: Symbols the agent has read completely (full body)
+
+For machine-readable output, pass `--format json` to emit a single-line, schema-versioned JSON object suitable for `jq` or other tooling:
+
+```bash
+ambits -p . --coverage --format json | jq '.totals.full_percent'
+```
 
 ### Multi-Agent Coverage
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -6,12 +6,13 @@
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::Result;
+use serde::Serialize;
 
 use crate::symbols::{ProjectTree, SymbolNode};
 use crate::tracking::{ContextLedger, ReadDepth};
 
 /// Per-file coverage metrics.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct FileCoverage {
     /// Full relative path to the file.
     pub path: String,
@@ -44,7 +45,7 @@ impl FileCoverage {
 }
 
 /// Complete coverage report for a project.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct CoverageReport {
     /// Session ID if available.
     pub session_id: Option<String>,
@@ -260,6 +261,76 @@ impl CoverageFormatter for TextFormatter {
     }
 }
 
+/// Compact JSON formatter for machine-readable output.
+///
+/// Emits a single-line, schema-versioned JSON object terminated by a newline.
+/// The wire format is intentionally decoupled from `CoverageReport`'s internal
+/// shape via a private DTO so percentages can be precomputed and field
+/// ordering (schema_version first) is guaranteed.
+#[derive(Debug, Clone, Default)]
+pub struct JsonFormatter;
+
+impl CoverageFormatter for JsonFormatter {
+    fn format(&self, report: &CoverageReport) -> String {
+        #[derive(Serialize)]
+        struct Totals {
+            symbols: usize,
+            seen: usize,
+            full: usize,
+            seen_percent: f64,
+            full_percent: f64,
+        }
+
+        #[derive(Serialize)]
+        struct FileDto<'a> {
+            path: &'a str,
+            total_symbols: usize,
+            seen_count: usize,
+            full_count: usize,
+            seen_percent: f64,
+            full_percent: f64,
+        }
+
+        #[derive(Serialize)]
+        struct ReportDto<'a> {
+            schema_version: u32,
+            session_id: Option<&'a str>,
+            agent_id: Option<&'a str>,
+            totals: Totals,
+            files: Vec<FileDto<'a>>,
+        }
+
+        let dto = ReportDto {
+            schema_version: 1,
+            session_id: report.session_id.as_deref(),
+            agent_id: report.agent_id.as_deref(),
+            totals: Totals {
+                symbols: report.total_symbols(),
+                seen: report.total_seen(),
+                full: report.total_full(),
+                seen_percent: report.total_seen_percent(),
+                full_percent: report.total_full_percent(),
+            },
+            files: report
+                .files
+                .iter()
+                .map(|f| FileDto {
+                    path: &f.path,
+                    total_symbols: f.total_symbols,
+                    seen_count: f.seen_count,
+                    full_count: f.full_count,
+                    seen_percent: f.seen_percent(),
+                    full_percent: f.full_percent(),
+                })
+                .collect(),
+        };
+
+        let mut out = serde_json::to_string(&dto).expect("CoverageReport DTO must serialize");
+        out.push('\n');
+        out
+    }
+}
+
 /// Run a coverage report for a project and print it to stdout.
 ///
 /// Resolves the log directory and session automatically when not provided.
@@ -271,6 +342,7 @@ pub fn run_report(
     session_opt: &Option<String>,
     agent_opt: &Option<String>,
     ingester: &dyn crate::ingest::SessionIngester,
+    formatter: &dyn CoverageFormatter,
 ) -> Result<()> {
     use crate::tracking::ContextLedger;
 
@@ -340,7 +412,6 @@ pub fn run_report(
     let mut report = CoverageReport::from_project(project_tree, &ledger, resolved_agent.as_deref());
     report.session_id = session_id;
 
-    let formatter = TextFormatter::default();
     print!("{}", formatter.format(&report));
 
     Ok(())
@@ -531,5 +602,36 @@ mod tests {
         assert!(output.contains("Coverage Report (session: abc-123)"));
         assert!(output.contains("src/main.rs"));
         assert!(output.contains("TOTAL"));
+    }
+
+    #[test]
+    fn json_formatter_includes_schema_version() {
+        let report = CoverageReport {
+            session_id: Some("s".into()),
+            agent_id: None,
+            files: vec![],
+        };
+        let output = JsonFormatter.format(&report);
+        let value: serde_json::Value =
+            serde_json::from_str(output.trim()).expect("output must be valid JSON");
+        assert_eq!(value["schema_version"], 1);
+    }
+
+    #[test]
+    fn json_formatter_compact_no_internal_newlines() {
+        let report = CoverageReport {
+            session_id: Some("s".into()),
+            agent_id: None,
+            files: vec![FileCoverage {
+                path: "a.rs".into(),
+                total_symbols: 1,
+                seen_count: 1,
+                full_count: 1,
+            }],
+        };
+        let output = JsonFormatter.format(&report);
+        assert!(output.ends_with('\n'), "output must end with a trailing newline");
+        let body = output.trim_end_matches('\n');
+        assert!(!body.contains('\n'), "JSON body must be a single line");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use clap::{Parser as ClapParser, Subcommand};
+use clap::{Parser as ClapParser, Subcommand, ValueEnum};
 use color_eyre::eyre::Result;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
@@ -73,8 +73,20 @@ struct Cli {
     #[arg(long)]
     tools_config: Option<PathBuf>,
 
+    /// Output format for --coverage. Ignored when --coverage is not set.
+    #[arg(long, value_enum, default_value = "table")]
+    format: CoverageFormat,
+
     #[command(subcommand)]
     command: Option<Commands>,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum CoverageFormat {
+    /// Human-readable ASCII table (default).
+    Table,
+    /// Compact, schema-versioned JSON on a single line.
+    Json,
 }
 
 #[derive(Subcommand, Debug)]
@@ -146,7 +158,19 @@ fn main() -> Result<()> {
         for w in &config_warnings {
             println!("[ambit warning] {w}");
         }
-        return coverage::run_report(&project_path, &project_tree, &cli.log_dir, &cli.session, &cli.agent, &*ingester);
+        let formatter: Box<dyn coverage::CoverageFormatter> = match cli.format {
+            CoverageFormat::Table => Box::new(coverage::TextFormatter::default()),
+            CoverageFormat::Json => Box::new(coverage::JsonFormatter),
+        };
+        return coverage::run_report(
+            &project_path,
+            &project_tree,
+            &cli.log_dir,
+            &cli.session,
+            &cli.agent,
+            &*ingester,
+            &*formatter,
+        );
     }
 
     // Resolve log directory and session.

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use ambits::app::App;
-use ambits::coverage::{CoverageFormatter, CoverageReport, TextFormatter};
+use ambits::coverage::{CoverageFormatter, CoverageReport, JsonFormatter, TextFormatter};
 use ambits::ingest::claude::parse_log_file;
 use ambits::ingest::tool_config::ToolMappingConfig;
 use ambits::ingest::AgentToolCall;
@@ -282,4 +282,81 @@ fn text_formatter_structure() {
     assert!(output.contains("mock/main.rs"), "should contain file path");
     assert!(output.contains("TOTAL"), "should contain total row");
     assert!(output.contains("100%"), "should show 100% for full coverage");
+}
+
+/// JsonFormatter emits the documented schema with totals, files, and schema_version.
+#[test]
+fn json_formatter_structure() {
+    let files = vec![
+        file("mock/main.rs", vec![sym("mock/main.rs::main", "main")]),
+    ];
+    let tree = project(files);
+    let mut ledger = ContextLedger::new();
+    ledger.record(
+        "mock/main.rs::main".into(),
+        ReadDepth::FullBody,
+        [0; 32],
+        "ag".into(),
+        10,
+    );
+
+    let mut report = CoverageReport::from_project(&tree, &ledger, None);
+    report.session_id = Some("test-session-456".into());
+
+    let output = JsonFormatter.format(&report);
+    let v: serde_json::Value =
+        serde_json::from_str(output.trim()).expect("output must be valid JSON");
+
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["session_id"], "test-session-456");
+    assert!(v["agent_id"].is_null());
+    assert_eq!(v["totals"]["symbols"], 1);
+    assert_eq!(v["totals"]["seen"], 1);
+    assert_eq!(v["totals"]["full"], 1);
+    assert_eq!(v["totals"]["seen_percent"], 100.0);
+    assert_eq!(v["totals"]["full_percent"], 100.0);
+
+    let files = v["files"].as_array().expect("files must be an array");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0]["path"], "mock/main.rs");
+    assert_eq!(files[0]["total_symbols"], 1);
+    assert_eq!(files[0]["seen_count"], 1);
+    assert_eq!(files[0]["full_count"], 1);
+    assert_eq!(files[0]["full_percent"], 100.0);
+}
+
+/// agent_id is null without a filter and the resolved id when filtered.
+#[test]
+fn json_formatter_agent_filter() {
+    let files = vec![file("a.rs", vec![sym("a.rs::x", "x")])];
+    let tree = project(files);
+    let mut ledger = ContextLedger::new();
+    ledger.record("a.rs::x".into(), ReadDepth::FullBody, [0; 32], "agent-foo".into(), 10);
+
+    let report_no_filter = CoverageReport::from_project(&tree, &ledger, None);
+    let v: serde_json::Value =
+        serde_json::from_str(JsonFormatter.format(&report_no_filter).trim()).unwrap();
+    assert!(v["agent_id"].is_null());
+
+    let report_filtered = CoverageReport::from_project(&tree, &ledger, Some("agent-foo"));
+    let v: serde_json::Value =
+        serde_json::from_str(JsonFormatter.format(&report_filtered).trim()).unwrap();
+    assert_eq!(v["agent_id"], "agent-foo");
+}
+
+/// Empty project serializes with zero totals and an empty files array.
+#[test]
+fn json_formatter_empty_project() {
+    let tree = project(vec![]);
+    let ledger = ContextLedger::new();
+    let report = CoverageReport::from_project(&tree, &ledger, None);
+
+    let output = JsonFormatter.format(&report);
+    let v: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["totals"]["symbols"], 0);
+    assert_eq!(v["totals"]["seen"], 0);
+    assert_eq!(v["totals"]["full"], 0);
+    assert_eq!(v["files"].as_array().unwrap().len(), 0);
 }


### PR DESCRIPTION
### Summary

- Adds a `--format` CLI flag (values: `table` | `json`) that controls the output format when `--coverage` is set
- Implements a new `JsonFormatter` behind the existing `CoverageFormatter` trait, emitting a single-line schema-versioned JSON object suitable for piping to `jq` or other tooling
- Refactors `run_report` to accept a `&dyn CoverageFormatter` instead of hardcoding `TextFormatter`, making the formatter selection the caller's responsibility

### Motivation

The ASCII table format is good for human eyes but awkward to consume in scripts, CI pipelines, or other tools. The JSON output provides a stable, versioned schema that can be queried directly:

```bash
ambits -p . --coverage --format json | jq '.totals.full_percent'
```

### Schema (`schema_version: 1`)

```json
{
  "schema_version": 1,
  "session_id": "...",
  "agent_id": null,
  "totals": { "symbols": 214, "seen": 182, "full": 175, "seen_percent": 85.0, "full_percent": 81.8 },
  "files": [{ "path": "src/main.rs", "total_symbols": 12, "seen_count": 10, "full_count": 8, "seen_percent": 83.3, "full_percent": 66.7 }]
}
```

### Test plan

- [ ] `cargo test` passes (unit tests in `coverage.rs`, e2e tests in `tests/e2e.rs`)
- [ ] `ambits -p . --coverage` still produces the table (default unchanged)
- [ ] `ambits -p . --coverage --format json | jq .totals` produces valid output
- [ ] `ambits -p . --coverage --format table` explicitly works
- [ ] `ambits -p . --dump --format json` is ignored gracefully (flag is no-op without `--coverage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)