### PR TITLE
Ref/improvements

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -93,6 +93,7 @@ pub struct App {
 
     // Session info for display.
     pub session_id: Option<String>,
+    pub session_slug: Option<String>,
 
     // Optional event log writer.
     pub event_log: Option<BufWriter<File>>,
@@ -126,6 +127,7 @@ impl App {
             search_mode: false,
             search_query: String::new(),
             session_id: None,
+            session_slug: None,
             event_log,
         };
         app.rebuild_tree_rows();
@@ -142,6 +144,7 @@ impl App {
         self.agent_tree = AgentTree::new();
         self.agent_filter = None;
         self.agent_selection_index = 0;
+        self.session_slug = None;
         self.rebuild_tree_rows();
     }
 
@@ -166,7 +169,7 @@ impl App {
                     )
                 })
                 .collect();
-            indices.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+            indices.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
             indices.into_iter().map(|(_, _, i)| i).collect()
         } else {
             (0..self.project_tree.files.len()).collect()

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use flume;
 use std::time::Duration;
 
 use crossterm::event::{self, Event, KeyEvent, MouseEvent};

--- a/src/ingest/claude.rs
+++ b/src/ingest/claude.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -9,21 +9,29 @@ use super::{AgentToolCall, EventTailer, SessionIngester, TailerOutput, ToolCallM
 use super::tool_config::ToolMappingConfig;
 
 /// Derive the Claude Code log directory for a given project path.
-/// Claude stores logs at ~/.claude/projects/<slug>/ where slug is the
-/// absolute path with `/` replaced by `-` and leading `-`.
+/// Probes two slug variants to stay resilient across Claude Code versions:
+///   1. Primary: replace '/' and '.' with '-' (observed current behavior)
+///   2. Fallback: replace only '/' — older builds may not replace dots
 pub fn log_dir_for_project(project_path: &Path) -> Option<PathBuf> {
     let canonical = project_path.canonicalize().ok()?;
-    let slug = canonical
-        .to_string_lossy()
-        .replace('/', "-")
-        .replace('.', "-");  // Claude Code also replaces dots with hyphens
     let home = dirs_home()?;
-    let dir = home.join(".claude").join("projects").join(&slug);
-    if dir.is_dir() {
-        Some(dir)
-    } else {
-        None
+    let base = home.join(".claude").join("projects");
+
+    let slug_primary = canonical
+        .to_string_lossy()
+        .replace(['/', '.'], "-");
+    let dir_primary = base.join(&slug_primary);
+    if dir_primary.is_dir() {
+        return Some(dir_primary);
     }
+
+    let slug_fallback = canonical.to_string_lossy().replace('/', "-");
+    let dir_fallback = base.join(&slug_fallback);
+    if dir_fallback.is_dir() {
+        return Some(dir_fallback);
+    }
+
+    None
 }
 
 fn dirs_home() -> Option<PathBuf> {
@@ -105,7 +113,10 @@ pub fn session_log_files(log_dir: &Path, session_id: &str) -> Vec<PathBuf> {
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("");
-                if name.starts_with("agent-") && name.ends_with(".jsonl") {
+                if name.starts_with("agent-")
+                    && name.ends_with(".jsonl")
+                    && !name.starts_with("agent-acompact-")
+                {
                     files.push(path);
                 }
             }
@@ -122,6 +133,7 @@ pub fn session_log_files(log_dir: &Path, session_id: &str) -> Vec<PathBuf> {
                 .unwrap_or("");
             if name.starts_with("agent-")
                 && name.ends_with(".jsonl")
+                && !name.starts_with("agent-acompact-")
                 && agent_belongs_to_session(&path, session_id)
             {
                 files.push(path);
@@ -149,23 +161,65 @@ fn agent_belongs_to_session(path: &Path, session_id: &str) -> bool {
     false
 }
 
+/// Return the fallback label for an agent log: the filename stem with "agent-" prefix stripped.
+fn default_label(path: &Path) -> String {
+    let stem = path
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+    stem.strip_prefix("agent-").unwrap_or(stem).to_string()
+}
+
+/// Scan a JSONL file line by line and return the first value found for `key`
+/// in any top-level JSON object. Lines that are not valid JSON are skipped.
+fn extract_jsonl_string_field(path: &Path, key: &str) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(obj) = serde_json::from_str::<Value>(trimmed) {
+            if let Some(val) = obj.get(key).and_then(|v| v.as_str()) {
+                return Some(val.to_string());
+            }
+        }
+    }
+}
+
+/// Extract the `slug` field from the first matching JSONL record in a session log file.
+pub fn extract_session_slug(path: &Path) -> Option<String> {
+    extract_jsonl_string_field(path, "slug")
+}
+
+/// Extract the `cwd` field from the first matching JSONL record in a log file.
+pub fn extract_cwd(path: &Path) -> Option<PathBuf> {
+    extract_jsonl_string_field(path, "cwd").map(PathBuf::from)
+}
+
+/// Remap `file_path` from `worktree_root` to `project_root` when the path is
+/// rooted inside the worktree. Returns the original path unchanged otherwise.
+pub fn remap_path(file_path: &Path, worktree_root: &Path, project_root: &Path) -> PathBuf {
+    if let Ok(rel) = file_path.strip_prefix(worktree_root) {
+        project_root.join(rel)
+    } else {
+        file_path.to_path_buf()
+    }
+}
+
 /// Extract a human-readable label for an agent from its JSONL log file.
 ///
 /// Reads the first line of the file and looks for:
 /// 1. The `message.content` field (the task prompt given to the agent) — truncated to 50 chars
 /// 2. Falls back to the filename stem (e.g., `agent-a9fe23c` → `a9fe23c`)
 pub fn extract_agent_label(path: &Path) -> String {
-    let fallback = path
-        .file_stem()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown")
-        .strip_prefix("agent-")
-        .unwrap_or_else(|| {
-            path.file_stem()
-                .and_then(|n| n.to_str())
-                .unwrap_or("unknown")
-        })
-        .to_string();
+    let fallback = default_label(path);
 
     let file = match fs::File::open(path) {
         Ok(f) => f,
@@ -212,29 +266,73 @@ pub enum ParsedLine {
 /// SessionCleared signals are ignored in batch mode — dump/coverage modes show
 /// aggregate historical coverage, not live session state.
 pub fn parse_log_file(path: &Path, config: &ToolMappingConfig) -> Vec<AgentToolCall> {
-    parse_log_file_with_mapper(path, config)
+    parse_log_file_with_mapper(path, config, None)
 }
 
-fn parse_log_file_with_mapper(path: &Path, mapper: &dyn ToolCallMapper) -> Vec<AgentToolCall> {
+fn parse_log_file_with_mapper(
+    path: &Path,
+    mapper: &dyn ToolCallMapper,
+    project_root: Option<&Path>,
+) -> Vec<AgentToolCall> {
     let mut events = Vec::new();
     let file = match fs::File::open(path) {
         Ok(f) => f,
         Err(_) => return events,
     };
-    let reader = BufReader::new(file);
 
-    // Derive a default agent ID from the filename.
     let default_id = path
         .file_stem()
         .and_then(|n| n.to_str())
         .unwrap_or("unknown")
         .to_string();
 
-    // Extract a human-readable label for this agent (Arc so each clone is free).
-    let label: Arc<str> = extract_agent_label(path).into();
+    let mut reader = BufReader::new(file);
+
+    // Read the first line once to extract the agent label and worktree cwd.
+    // This avoids a second file open for extract_agent_label / extract_cwd.
+    let mut first_line = String::new();
+    let _ = reader.read_line(&mut first_line);
+    let first_trimmed = first_line.trim();
+
+    let first_parsed: Option<Value> = serde_json::from_str(first_trimmed).ok();
+    let label: Arc<str> = match first_parsed.as_ref() {
+        Some(obj) => {
+            let content = obj.pointer("/message/content").and_then(|v| v.as_str()).unwrap_or("");
+            if content.is_empty() {
+                Arc::from(default_label(path).as_str())
+            } else {
+                let line_content = content.lines().next().unwrap_or(content);
+                if line_content.len() <= 50 {
+                    Arc::from(line_content)
+                } else {
+                    Arc::from(format!("{}...", &line_content[..47]).as_str())
+                }
+            }
+        }
+        None => Arc::from(default_label(path).as_str()),
+    };
+
+    // Detect worktree: cwd in the first record differs from the project root.
+    let cwd_remap: Option<(PathBuf, PathBuf)> = project_root.and_then(|root| {
+        let obj = first_parsed.as_ref()?;
+        let cwd = PathBuf::from(obj.get("cwd")?.as_str()?);
+        if cwd != root { Some((cwd, root.to_path_buf())) } else { None }
+    });
+
+    // Seek back to start so all lines — including line 1 — are processed for events.
+    let _ = reader.seek(SeekFrom::Start(0));
 
     for line in reader.lines().map_while(Result::ok) {
-        if let ParsedLine::Events(mut line_events) = parse_jsonl_line(&line, &default_id, mapper) {
+        if let ParsedLine::Events(mut line_events) =
+            parse_jsonl_line(line.trim(), &default_id, mapper)
+        {
+            if let Some((ref worktree, ref project)) = cwd_remap {
+                for ev in &mut line_events {
+                    if let Some(ref fp) = ev.file_path {
+                        ev.file_path = Some(remap_path(fp, worktree, project));
+                    }
+                }
+            }
             for ev in &mut line_events {
                 ev.label = label.clone();
             }
@@ -630,7 +728,14 @@ impl SessionIngester for ClaudeIngester {
         session_log_files(log_dir, session_id)
     }
     fn parse_log_file(&self, path: &Path) -> Vec<AgentToolCall> {
-        parse_log_file_with_mapper(path, &*self.mapper)
+        parse_log_file_with_mapper(path, &*self.mapper, None)
+    }
+    fn parse_log_file_with_root(&self, path: &Path, project_root: &Path) -> Vec<AgentToolCall> {
+        parse_log_file_with_mapper(path, &*self.mapper, Some(project_root))
+    }
+    fn session_slug(&self, log_dir: &Path, session_id: &str) -> Option<String> {
+        let path = log_dir.join(format!("{session_id}.jsonl"));
+        extract_session_slug(&path)
     }
     fn new_tailer(&self, files: Vec<PathBuf>) -> Box<dyn EventTailer> {
         Box::new(LogTailer::new(files, Arc::clone(&self.mapper)))
@@ -1204,6 +1309,139 @@ description  = "UserTool {target}"
     }
 
     // -----------------------------------------------------------------------
+    // Slug, cwd, remap, and acompact filter tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_slug_reads_from_first_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("session.jsonl");
+        fs::write(&log, r#"{"type":"user","slug":"crispy-crunching-nova","sessionId":"abc"}"#).unwrap();
+        assert_eq!(extract_session_slug(&log), Some("crispy-crunching-nova".into()));
+    }
+
+    #[test]
+    fn extract_slug_skips_records_without_slug() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("session.jsonl");
+        fs::write(&log,
+            "{\"type\":\"queue-operation\",\"sessionId\":\"abc\"}\n\
+             {\"type\":\"user\",\"slug\":\"amber-dancing-fox\",\"sessionId\":\"abc\"}\n"
+        ).unwrap();
+        assert_eq!(extract_session_slug(&log), Some("amber-dancing-fox".into()));
+    }
+
+    #[test]
+    fn extract_slug_returns_none_for_missing_file() {
+        assert_eq!(extract_session_slug(Path::new("/nonexistent/session.jsonl")), None);
+    }
+
+    #[test]
+    fn extract_slug_returns_none_when_no_slug_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("session.jsonl");
+        fs::write(&log, r#"{"type":"queue-operation","sessionId":"abc"}"#).unwrap();
+        assert_eq!(extract_session_slug(&log), None);
+    }
+
+    #[test]
+    fn extract_cwd_reads_first_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("agent.jsonl");
+        fs::write(&log, r#"{"type":"user","cwd":"/tmp/worktree-xyz","sessionId":"s1"}"#).unwrap();
+        assert_eq!(extract_cwd(&log), Some(PathBuf::from("/tmp/worktree-xyz")));
+    }
+
+    #[test]
+    fn remap_path_strips_worktree_prefix() {
+        let worktree = PathBuf::from("/tmp/worktree-abc");
+        let project  = PathBuf::from("/home/user/myproject");
+        let file     = PathBuf::from("/tmp/worktree-abc/src/main.rs");
+        assert_eq!(
+            remap_path(&file, &worktree, &project),
+            PathBuf::from("/home/user/myproject/src/main.rs"),
+        );
+    }
+
+    #[test]
+    fn remap_path_unchanged_when_no_prefix_match() {
+        let worktree = PathBuf::from("/tmp/worktree-abc");
+        let project  = PathBuf::from("/home/user/myproject");
+        let file     = PathBuf::from("/home/user/myproject/src/main.rs");
+        assert_eq!(remap_path(&file, &worktree, &project), file);
+    }
+
+    #[test]
+    fn session_log_files_excludes_acompact_agents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session = "abcd1234-abcd-abcd-abcd-abcd12345678";
+        let subagents_dir = tmp.path().join(session).join("subagents");
+        fs::create_dir_all(&subagents_dir).unwrap();
+
+        let real = subagents_dir.join("agent-abc123.jsonl");
+        fs::write(&real, r#"{"type":"user"}"#).unwrap();
+        let compact = subagents_dir.join("agent-acompact-0687bac42d56804e.jsonl");
+        fs::write(&compact, r#"{"type":"user","isMeta":true}"#).unwrap();
+
+        let main_file = tmp.path().join(format!("{session}.jsonl"));
+        fs::write(&main_file, r#"{"type":"user"}"#).unwrap();
+
+        let files = session_log_files(tmp.path(), session);
+        assert!(files.contains(&real), "real subagent must be included");
+        assert!(!files.contains(&compact), "acompact agent must be excluded");
+    }
+
+    #[test]
+    fn parse_log_file_remaps_worktree_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let worktree = tmp.path().join("worktree");
+        let project  = tmp.path().join("project");
+        fs::create_dir_all(&worktree).unwrap();
+        fs::create_dir_all(&project).unwrap();
+
+        let log = worktree.join("agent.jsonl");
+        let mut f = fs::File::create(&log).unwrap();
+        writeln!(f, r#"{{"type":"user","cwd":"{}","sessionId":"s1"}}"#,
+            worktree.to_str().unwrap()).unwrap();
+        writeln!(f, "{}", jsonl_assistant("mcp__acp__Read", &format!(
+            r#"{{"file_path":"{}/src/main.rs"}}"#, worktree.to_str().unwrap()
+        ))).unwrap();
+        drop(f);
+
+        let config = ToolMappingConfig::builtin().unwrap();
+        let events = parse_log_file_with_mapper(&log, &config, Some(&project));
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].file_path.as_ref().unwrap(),
+            &project.join("src/main.rs"),
+        );
+    }
+
+    #[test]
+    fn parse_log_file_no_remap_when_cwd_matches_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+
+        let log = project.join("session.jsonl");
+        let mut f = fs::File::create(&log).unwrap();
+        writeln!(f, r#"{{"type":"user","cwd":"{}","sessionId":"s1"}}"#,
+            project.to_str().unwrap()).unwrap();
+        writeln!(f, "{}", jsonl_assistant("mcp__acp__Read", &format!(
+            r#"{{"file_path":"{}/src/main.rs"}}"#, project.to_str().unwrap()
+        ))).unwrap();
+        drop(f);
+
+        let config = ToolMappingConfig::builtin().unwrap();
+        let events = parse_log_file_with_mapper(&log, &config, Some(&project));
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].file_path.as_ref().unwrap(),
+            &project.join("src/main.rs"),
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Bash per-command depth dispatch
     // -----------------------------------------------------------------------
 
@@ -1250,5 +1488,15 @@ description  = "UserTool {target}"
         // Unrecognised commands fall back to the PatternMatch default (NameOnly).
         assert_eq!(bash_event("cargo build --release").read_depth, ReadDepth::NameOnly);
         assert_eq!(bash_event("npm install").read_depth, ReadDepth::NameOnly);
+    }
+
+    #[test]
+    fn bash_ugrep_gets_overview() {
+        assert_eq!(bash_event("ugrep 'fn main' src/").read_depth, ReadDepth::Overview);
+    }
+
+    #[test]
+    fn bash_bfs_gets_name_only() {
+        assert_eq!(bash_event("bfs . -name '*.rs'").read_depth, ReadDepth::NameOnly);
     }
 }

--- a/src/ingest/default_tools.toml
+++ b/src/ingest/default_tools.toml
@@ -123,8 +123,10 @@ depth         = { type = "pattern_match", key = "command", default = "NameOnly",
     { prefix = "grep ", depth = "Overview" },
     { prefix = "rg ",   depth = "Overview" },
     { prefix = "awk ",  depth = "Overview" },
-    { prefix = "sed ",  depth = "Overview" },
-    { prefix = "git ",  depth = "Unseen" },
+    { prefix = "sed ",   depth = "Overview"  },
+    { prefix = "ugrep ", depth = "Overview"  },
+    { prefix = "bfs ",   depth = "NameOnly"  },
+    { prefix = "git ",   depth = "Unseen"    },
 ] }
 description   = "Bash {pattern|cmd}"
 
@@ -135,3 +137,59 @@ path_required = false
 pattern_keys  = []
 depth         = { type = "fixed", value = "NameOnly" }
 description   = "TodoWrite {pattern|cmd}"
+
+[[tool]]
+names         = ["Agent"]
+path_keys     = []
+path_required = false
+pattern_keys  = ["description"]
+depth         = { type = "fixed", value = "Unseen" }
+description   = "Agent: {pattern}"
+
+[[tool]]
+names         = ["ToolSearch"]
+path_keys     = []
+path_required = false
+pattern_keys  = ["query"]
+depth         = { type = "fixed", value = "Unseen" }
+description   = "ToolSearch {pattern}"
+
+[[tool]]
+names         = ["Skill"]
+path_keys     = []
+path_required = false
+pattern_keys  = ["skill"]
+depth         = { type = "fixed", value = "NameOnly" }
+description   = "Skill {pattern}"
+
+[[tool]]
+names         = ["SendMessage"]
+path_keys     = []
+path_required = false
+pattern_keys  = ["to"]
+depth         = { type = "fixed", value = "Unseen" }
+description   = "SendMessage {pattern}"
+
+[[tool]]
+names         = ["TaskList"]
+path_keys     = []
+path_required = false
+pattern_keys  = []
+depth         = { type = "fixed", value = "Unseen" }
+description   = "TaskList"
+
+[[tool]]
+names         = ["AskUserQuestion"]
+path_keys     = []
+path_required = false
+pattern_keys  = ["question"]
+depth         = { type = "fixed", value = "Unseen" }
+description   = "AskUserQuestion"
+
+[[tool]]
+names         = ["WebFetch", "WebSearch"]
+path_keys     = []
+path_required = false
+pattern_keys  = ["url", "query"]
+depth         = { type = "fixed", value = "Unseen" }
+description   = "Web {pattern}"

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -55,6 +55,21 @@ pub trait SessionIngester: Send + Sync {
     fn parse_log_file(&self, path: &Path) -> Vec<AgentToolCall>;
     /// Create a new incremental event tailer for the given set of files.
     fn new_tailer(&self, files: Vec<PathBuf>) -> Box<dyn EventTailer>;
+
+    /// Return the human-readable slug for a session (e.g. "crispy-crunching-nova").
+    /// Default returns None; implementations override this for slug-carrying formats.
+    fn session_slug(&self, log_dir: &Path, session_id: &str) -> Option<String> {
+        let _ = (log_dir, session_id);
+        None
+    }
+
+    /// Parse all events from a log file, remapping paths when the agent ran in a
+    /// worktree whose cwd differs from `project_root`.
+    /// Default delegates to `parse_log_file` (no remapping).
+    fn parse_log_file_with_root(&self, path: &Path, project_root: &Path) -> Vec<AgentToolCall> {
+        let _ = project_root;
+        self.parse_log_file(path)
+    }
 }
 
 /// Stateful incremental reader. Created via `SessionIngester::new_tailer`.

--- a/src/ingest/tool_config.rs
+++ b/src/ingest/tool_config.rs
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     fn builtin_config_parses() {
         let cfg = ToolMappingConfig::builtin().expect("built-in config must parse");
-        assert_eq!(cfg.tools.len(), 15);
+        assert_eq!(cfg.tools.len(), 22);
         assert!(!cfg.index.is_empty());
     }
 
@@ -763,7 +763,7 @@ description  = "Foo"
     fn resolve_falls_back_to_builtin() {
         // Pass a non-existent path — resolve() should silently fall back.
         let (cfg, warnings) = ToolMappingConfig::resolve(Some(std::path::Path::new("/nonexistent/tools.toml")));
-        assert_eq!(cfg.tools.len(), 15, "should have 15 built-in tools");
+        assert_eq!(cfg.tools.len(), 22, "should have 22 built-in tools");
         // No warnings since the file simply doesn't exist (no ParseError).
         assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,12 +206,15 @@ fn main() -> Result<()> {
 
     let mut app = App::new(project_tree, project_path.clone(), event_log);
     app.session_id = session_id.clone();
+    app.session_slug = log_dir.as_ref()
+        .zip(session_id.as_ref())
+        .and_then(|(ld, sid)| ingester.session_slug(ld, sid));
 
     // Pre-populate the ledger from existing session logs.
     if let (Some(ref log_dir), Some(ref session_id)) = (&log_dir, &session_id) {
         let log_files = ingester.session_log_files(log_dir, session_id);
         for log_file in &log_files {
-            for event in ingester.parse_log_file(log_file) {
+            for event in ingester.parse_log_file_with_root(log_file, &project_path) {
                 app.process_agent_event(event);
             }
         }

--- a/src/symbols/merkle.rs
+++ b/src/symbols/merkle.rs
@@ -90,7 +90,7 @@ pub fn estimate_tokens(source: &str) -> usize {
             word_len += 1;
         } else {
             if word_len > 0 {
-                count += (word_len + 3) / 4;
+                count += word_len.div_ceil(4);
                 word_len = 0;
             }
             if !ch.is_whitespace() {
@@ -99,7 +99,7 @@ pub fn estimate_tokens(source: &str) -> usize {
         }
     }
     if word_len > 0 {
-        count += (word_len + 3) / 4;
+        count += word_len.div_ceil(4);
     }
     count
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -140,11 +140,14 @@ impl TuiSession {
                     app.reset_session();
                     self.current_session_id = Some(latest.clone());
                     app.session_id = self.current_session_id.clone();
+                    app.session_slug = log_dir.as_ref()
+                        .zip(self.current_session_id.as_ref())
+                        .and_then(|(ld2, sid)| self.ingester.session_slug(ld2, sid));
 
                     // Pre-populate from lines already written before this tick.
                     let new_files = self.ingester.session_log_files(ld, &latest);
                     for log_file in &new_files {
-                        for event in self.ingester.parse_log_file(log_file) {
+                        for event in self.ingester.parse_log_file_with_root(log_file, project_path) {
                             app.process_agent_event(event);
                         }
                     }

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -79,12 +79,18 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         ]),
     ];
 
-    // Session info.
-    if let Some(ref sid) = app.session_id {
-        let short = if sid.len() > 12 { &sid[..12] } else { sid };
+    // Session info: prefer human-readable slug; fall back to first 12 chars of UUID.
+    let session_label: Option<&str> = if let Some(slug) = app.session_slug.as_deref() {
+        Some(slug)
+    } else if let Some(sid) = app.session_id.as_deref() {
+        Some(if sid.len() > 12 { &sid[..12] } else { sid })
+    } else {
+        None
+    };
+    if let Some(label) = session_label {
         lines.push(Line::from(vec![
             Span::raw("  Session: "),
-            Span::styled(short, Style::default().fg(colors::ACCENT_MUTED)),
+            Span::styled(label, Style::default().fg(colors::ACCENT_MUTED)),
         ]));
     }
 
@@ -129,7 +135,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
             // Determine if this is the last sibling at its indent level.
             let is_last_sibling = flat[i + 1..]
                 .iter()
-                .all(|(_, d)| *d > *indent || *d < *indent)
+                .all(|(_, d)| *d != *indent)
                 || flat[i + 1..]
                     .iter()
                     .take_while(|(_, d)| *d >= *indent)

--- a/tests/integration_tool_config.rs
+++ b/tests/integration_tool_config.rs
@@ -224,6 +224,97 @@ fn tool_notebook_edit() {
 }
 
 // ---------------------------------------------------------------------------
+// 16. Agent
+// ---------------------------------------------------------------------------
+#[test]
+fn tool_agent_maps_with_description() {
+    let cfg = builtin();
+    let input = serde_json::json!({ "description": "Explore parser", "subagent_type": "Explore", "prompt": "..." });
+    let call = map_tool_call(&cfg, "Agent", &input, "a", "ts").unwrap();
+    assert_eq!(call.read_depth, ReadDepth::Unseen);
+    assert!(call.description.contains("Explore parser"), "description was: {}", call.description);
+}
+
+// ---------------------------------------------------------------------------
+// 17. ToolSearch
+// ---------------------------------------------------------------------------
+#[test]
+fn tool_search_gets_unseen() {
+    let cfg = builtin();
+    let input = serde_json::json!({ "query": "select:Read,Edit" });
+    let call = map_tool_call(&cfg, "ToolSearch", &input, "a", "ts").unwrap();
+    assert_eq!(call.read_depth, ReadDepth::Unseen);
+    assert!(call.description.contains("select:Read,Edit"), "description was: {}", call.description);
+}
+
+// ---------------------------------------------------------------------------
+// 18. Skill
+// ---------------------------------------------------------------------------
+#[test]
+fn tool_skill_gets_name_only() {
+    let cfg = builtin();
+    let input = serde_json::json!({ "skill": "rust-skills:m01-ownership" });
+    let call = map_tool_call(&cfg, "Skill", &input, "a", "ts").unwrap();
+    assert_eq!(call.read_depth, ReadDepth::NameOnly);
+    assert!(call.description.contains("rust-skills:m01-ownership"), "description was: {}", call.description);
+}
+
+// ---------------------------------------------------------------------------
+// 19. SendMessage
+// ---------------------------------------------------------------------------
+#[test]
+fn tool_send_message_gets_unseen() {
+    let cfg = builtin();
+    let input = serde_json::json!({ "to": "agent-abc", "message": "hi" });
+    let call = map_tool_call(&cfg, "SendMessage", &input, "a", "ts").unwrap();
+    assert_eq!(call.read_depth, ReadDepth::Unseen);
+    assert!(call.description.contains("agent-abc"), "description was: {}", call.description);
+}
+
+// ---------------------------------------------------------------------------
+// 20. TaskList
+// ---------------------------------------------------------------------------
+#[test]
+fn tool_task_list_gets_unseen() {
+    let cfg = builtin();
+    let input = serde_json::json!({});
+    let call = map_tool_call(&cfg, "TaskList", &input, "a", "ts").unwrap();
+    assert_eq!(call.read_depth, ReadDepth::Unseen);
+}
+
+// ---------------------------------------------------------------------------
+// 21. AskUserQuestion
+// ---------------------------------------------------------------------------
+#[test]
+fn tool_ask_user_question_gets_unseen() {
+    let cfg = builtin();
+    let input = serde_json::json!({ "question": "Proceed?", "options": ["Yes", "No"] });
+    let call = map_tool_call(&cfg, "AskUserQuestion", &input, "a", "ts").unwrap();
+    assert_eq!(call.read_depth, ReadDepth::Unseen);
+}
+
+// ---------------------------------------------------------------------------
+// 22. WebFetch / WebSearch
+// ---------------------------------------------------------------------------
+#[test]
+fn tool_web_fetch_gets_unseen() {
+    let cfg = builtin();
+    let input = serde_json::json!({ "url": "https://example.com" });
+    let call = map_tool_call(&cfg, "WebFetch", &input, "a", "ts").unwrap();
+    assert_eq!(call.read_depth, ReadDepth::Unseen);
+    assert!(call.description.contains("https://example.com"), "description was: {}", call.description);
+}
+
+#[test]
+fn tool_web_search_gets_unseen() {
+    let cfg = builtin();
+    let input = serde_json::json!({ "query": "rust error handling" });
+    let call = map_tool_call(&cfg, "WebSearch", &input, "a", "ts").unwrap();
+    assert_eq!(call.read_depth, ReadDepth::Unseen);
+    assert!(call.description.contains("rust error handling"), "description was: {}", call.description);
+}
+
+// ---------------------------------------------------------------------------
 // Unknown tool — returns None
 // ---------------------------------------------------------------------------
 #[test]


### PR DESCRIPTION
## Summary

- **New tool mappings** — Added 7 entries to `default_tools.toml` (`Agent`, `ToolSearch`, `Skill`, `SendMessage`, `TaskList`, `AskUserQuestion`, `WebFetch`/`WebSearch`) and two new Bash prefixes (`ugrep`, `bfs`), bringing the built-in tool count from 15 to 22.
- **Worktree-aware ingestion** — Added `session_slug()` and `parse_log_file_with_root()` to the `SessionIngester` trait. The latter remaps file paths when the agent ran in a worktree whose `cwd` differs from the project root. Both startup and live-session paths now use it.
- **Session slug display** — `App` now resolves and stores the human-readable session slug (e.g. `crispy-crunching-nova`) at startup and on session switch, enabling the stats panel to show it instead of a raw UUID prefix.
- **Code cleanup** — Merged redundant `replace` calls into a single-pass char array, eliminated a double JSON parse in the log reader, removed a needless borrow, simplified a boolean expression, replaced manual ceiling division with `div_ceil`, and dropped an unused import.

## Test plan

- [ ] `cargo test` passes (includes 9 new integration tests covering all new tool mappings)
- [ ] `cargo check` clean — no new warnings introduced
- [ ] Smoke-test against a real Claude Code session with a worktree to verify path remapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)