### PR TITLE
Compaction awareness for context coverage

### DIFF
--- a/docs/spikes/compaction-awareness.md
+++ b/docs/spikes/compaction-awareness.md
@@ -1,0 +1,480 @@
+# Spike: Compaction Awareness
+
+**Status**: Ready for implementation  
+**Branch target**: feature/compaction-awareness  
+**References**: https://platform.claude.com/docs/en/build-with-claude/compaction
+
+---
+
+## Background
+
+Claude Code uses server-side context compaction (`compact-2026-01-12` beta) to summarize older conversation history when approaching token limits. When compaction fires, Claude produces a `compaction` block in its assistant response — a prose summary of the context it is dropping. This event appears in the JSONL session logs ambit already reads.
+
+Currently ambit ignores compaction completely (`parse_compact_command_returns_ignored` test). This spike adds full awareness: detect compaction boundaries, snapshot ledger state at each boundary, surface the data in the TUI and coverage reports.
+
+---
+
+## JSONL Log Signal
+
+A compaction event appears as an `assistant` record whose `message.content` array contains a block with `"type": "compaction"`:
+
+```json
+{
+  "type": "assistant",
+  "timestamp": "2026-05-11T14:23:00Z",
+  "sessionId": "abc123",
+  "message": {
+    "content": [
+      {
+        "type": "compaction",
+        "content": "Summary of the conversation: The user is building a CLI parser..."
+      },
+      {
+        "type": "text",
+        "text": "Based on our conversation so far..."
+      }
+    ]
+  }
+}
+```
+
+A `/compact` user command (manual trigger) already appears in logs as a user message and is currently ignored — leave it ignored, only the resulting `compaction` block in the assistant response matters.
+
+The `agent-acompact-*` JSONL files are already excluded from `session_log_files` — do not change that.
+
+---
+
+## Architecture Overview
+
+### Core principle
+
+ambit's ledger does not forget when Claude does. Compaction affects Claude's context window, not our recorded tool calls. The meaningful data is:
+
+- **Pre-compaction slice**: what files and symbols the agent had accessed up to the boundary
+- **Summary text**: what Claude distilled that history into
+- **Post-compaction slice**: what has been accessed since (derived live from current ledger state)
+
+This naturally extends to N compactions by keeping an ordered `Vec<CompactionEvent>`.
+
+---
+
+## Implementation Plan
+
+### Step 1 — Extend `ParsedLine` (`src/ingest/claude.rs`)
+
+Add a `Compacted` arm to the existing enum:
+
+```rust
+pub enum ParsedLine {
+    Events(Vec<AgentToolCall>),
+    Compacted { summary: String, timestamp: String },
+    SessionCleared,
+    Ignored,
+}
+```
+
+In `parse_jsonl_line`, after confirming `msg_type == "assistant"`, scan the content array for a block where `block["type"] == "compaction"` and extract `block["content"].as_str()` as the summary. Return `ParsedLine::Compacted` immediately when found (before the tool-use loop, since compaction and tool-use blocks are mutually exclusive in practice).
+
+```rust
+// Inside parse_jsonl_line, after the assistant check:
+for block in content {
+    if block.get("type").and_then(|v| v.as_str()) == Some("compaction") {
+        let summary = block
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        return ParsedLine::Compacted { summary, timestamp: timestamp_str };
+    }
+}
+// existing tool_use loop follows...
+```
+
+Add a unit test `parse_compaction_block_returns_compacted` alongside the existing `parse_compact_command_returns_ignored`.
+
+---
+
+### Step 2 — Introduce `SessionEvent` (`src/ingest/mod.rs`)
+
+Replace `Vec<AgentToolCall>` return types with a richer ordered enum:
+
+```rust
+pub enum SessionEvent {
+    ToolCall(AgentToolCall),
+    Compacted { summary: String, timestamp: String, agent_id: Arc<str> },
+    SessionCleared,
+}
+```
+
+Update `SessionIngester` trait:
+
+```rust
+pub trait SessionIngester: Send + Sync {
+    // existing methods unchanged...
+    fn parse_log_file(&self, path: &Path) -> Vec<SessionEvent>;
+    fn parse_log_file_with_root(&self, path: &Path, project_root: &Path) -> Vec<SessionEvent>;
+}
+```
+
+Update `parse_log_file_with_mapper` in `claude.rs` to emit `SessionEvent::Compacted` when `ParsedLine::Compacted` is returned, preserving log order.
+
+Update all callers (`main.rs`, `tui.rs`, `coverage.rs`) to match on `SessionEvent` instead of iterating `AgentToolCall` directly.
+
+---
+
+### Step 3 — New data types (`src/ingest/mod.rs` or `src/compaction.rs`)
+
+```rust
+/// Point-in-time ledger snapshot captured at a compaction boundary.
+pub struct LedgerSnapshot {
+    pub tool_call_count: usize,
+    pub files_accessed: BTreeSet<PathBuf>,  // relative paths, sorted
+    pub symbols_seen: usize,
+    pub seen_percent: f64,
+}
+
+/// A detected compaction event with summary and pre-compaction state.
+pub struct CompactionEvent {
+    pub sequence: u32,           // 1-based: 1st, 2nd, 3rd compaction
+    pub timestamp: String,
+    pub agent_id: Arc<str>,
+    pub summary: String,
+    pub ledger_before: LedgerSnapshot,
+}
+```
+
+---
+
+### Step 4 — `AppEvent` extension (`src/events.rs`)
+
+```rust
+pub enum AppEvent {
+    Key(KeyEvent),
+    Mouse(MouseEvent),
+    FileChanged(PathBuf),
+    AgentEvent(AgentToolCall),
+    SessionCleared,
+    Compacted(CompactionEvent),  // ← new
+    Tick,
+}
+```
+
+---
+
+### Step 5 — `App` state and processing (`src/app.rs`)
+
+New fields on `App`:
+
+```rust
+pub struct App {
+    // existing fields unchanged...
+    pub compaction_history: Vec<CompactionEvent>,
+    pub compaction_call_count: usize,   // running tool call counter
+}
+```
+
+New method. Derives the file list from the project tree + ledger at snapshot time — no ledger schema changes needed:
+
+```rust
+pub fn process_compaction(
+    &mut self,
+    summary: String,
+    timestamp: String,
+    agent_id: Arc<str>,
+) {
+    let files_before: BTreeSet<PathBuf> = self.project_tree.files.iter()
+        .filter(|f| {
+            f.symbols.iter().any(|sym| self.ledger.depth_of(&sym.id).is_seen())
+        })
+        .map(|f| f.file_path.clone())
+        .collect();
+
+    let total = self.project_tree.total_symbols();
+    let seen = self.ledger.total_seen();
+
+    let snapshot = LedgerSnapshot {
+        tool_call_count: self.compaction_call_count,
+        files_accessed: files_before,
+        symbols_seen: seen,
+        seen_percent: if total > 0 {
+            seen as f64 / total as f64 * 100.0
+        } else { 0.0 },
+    };
+
+    self.compaction_history.push(CompactionEvent {
+        sequence: self.compaction_history.len() as u32 + 1,
+        timestamp,
+        agent_id,
+        summary,
+        ledger_before: snapshot,
+    });
+}
+```
+
+Increment `compaction_call_count` in `process_agent_event`:
+
+```rust
+pub fn process_agent_event(&mut self, event: AgentToolCall) {
+    self.compaction_call_count += 1;
+    // existing logic...
+}
+```
+
+Update `reset_session` to clear both new fields.
+
+---
+
+### Step 6 — Event dispatch (`main.rs`, `tui.rs`)
+
+Update the pre-population loop in `main.rs`:
+
+```rust
+for event in ingester.parse_log_file_with_root(log_file, &project_path) {
+    match event {
+        SessionEvent::ToolCall(tc)               => app.process_agent_event(tc),
+        SessionEvent::Compacted { summary, timestamp, agent_id } => {
+            app.process_compaction(summary, timestamp, agent_id);
+        }
+        SessionEvent::SessionCleared             => app.reset_session(),
+    }
+}
+```
+
+Same pattern in `tui.rs` for live-session pre-population on session switch.
+
+Wire `AppEvent::Compacted(ev)` in the TUI event loop to call `app.process_compaction(...)`.
+
+---
+
+### Step 7 — TUI: activity feed marker (`src/ui/activity.rs`)
+
+Render a distinct separator line when a compaction is present in the activity stream. Since the activity feed is currently event-list-based, the cleanest approach is to record compaction events as a synthetic entry in the activity list with a special render style:
+
+```
+─── compaction #1 · 31.2% seen · 12 files ───────────────────
+```
+
+Style: `Color::Yellow` or `Color::Magenta`, full-width rule with summary info inline.
+
+---
+
+### Step 8 — TUI: compaction diff overlay (`src/ui/compaction.rs`)
+
+A new toggle panel activated by pressing `C` (capital). Renders the last compaction by default; `[` / `]` step through `compaction_history`.
+
+Layout:
+
+```
+┌─ Compaction #1 — 2026-05-11 14:23 ──────────────────────────┐
+│ Summary                                                       │
+│   "The user is building a CLI parser. Files modified:        │
+│    src/parser/mod.rs, src/cli.rs. Next step: flag validation"│
+├───────────────────────────────────────────────────────────────┤
+│ Before (47 calls · 12 files · 31.2% seen)                    │
+│   src/cli.rs                    FullBody                      │
+│   src/parser/mod.rs             Signature                     │
+│   src/parser/rust.rs            Overview                      │
+│   src/symbols/mod.rs            NameOnly                      │
+│   ... (8 more)                                                │
+├───────────────────────────────────────────────────────────────┤
+│ After  (current · 8 calls since compaction)                   │
+│   src/main.rs                   NameOnly                      │
+└───────────────────────────────────────────────────────────────┘
+```
+
+"After" side is derived live from the current ledger minus the pre-compaction snapshot — files that appear in the current ledger but were not in `ledger_before.files_accessed`.
+
+Add `FocusPanel::CompactionOverlay` variant or a boolean `show_compaction_overlay: bool` on `App` — prefer the boolean to avoid changing focus cycle logic.
+
+---
+
+### Step 9 — Stats panel (`src/ui/stats.rs`)
+
+Append to the stats panel when `!app.compaction_history.is_empty()`:
+
+```
+  Compactions: 2
+  Last: 2026-05-11 15:41  58.0% seen before
+```
+
+---
+
+## Coverage Report Extension (`src/coverage.rs`)
+
+### New type
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct CompactionSummary {
+    pub sequence: u32,
+    pub timestamp: String,
+    pub summary: String,
+    pub tool_calls_before: usize,
+    pub files_before: Vec<String>,       // relative paths, sorted
+    pub symbols_seen_before: usize,
+    pub seen_percent_before: f64,
+}
+```
+
+### `CoverageReport` extension
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct CoverageReport {
+    pub session_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub files: Vec<FileCoverage>,
+    pub compactions: Vec<CompactionSummary>,  // ← new, empty when none
+}
+```
+
+### `run_report` loop
+
+Maintain a `BTreeSet<PathBuf>` alongside the ledger. Snapshot it on each `SessionEvent::Compacted`:
+
+```rust
+let mut files_accessed: BTreeSet<PathBuf> = BTreeSet::new();
+let mut tool_call_count: usize = 0;
+let mut compactions: Vec<CompactionSummary> = Vec::new();
+
+for event in ingester.parse_log_file_with_root(log_file, project_path) {
+    match event {
+        SessionEvent::ToolCall(tc) => {
+            tool_call_count += 1;
+            if let Some(ref fp) = tc.file_path {
+                let rel = normalize_tool_path(fp, project_path);
+                files_accessed.insert(rel.clone());
+            }
+            // existing ledger-update / mark_file_symbols logic...
+        }
+        SessionEvent::Compacted { summary, timestamp, .. } => {
+            let seen = ledger.total_seen();
+            let total = project_tree.total_symbols();
+            compactions.push(CompactionSummary {
+                sequence: compactions.len() as u32 + 1,
+                timestamp,
+                summary,
+                tool_calls_before: tool_call_count,
+                files_before: files_accessed.iter()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .collect(),
+                symbols_seen_before: seen,
+                seen_percent_before: if total > 0 {
+                    seen as f64 / total as f64 * 100.0
+                } else { 0.0 },
+            });
+        }
+        SessionEvent::SessionCleared => {
+            ledger = ContextLedger::new();
+            files_accessed.clear();
+        }
+    }
+}
+
+let mut report = CoverageReport::from_project(project_tree, &ledger, resolved_agent.as_deref());
+report.session_id = session_id;
+report.compactions = compactions;
+```
+
+### Text formatter output
+
+After the TOTAL row, when `!report.compactions.is_empty()`:
+
+```
+Context Compactions (2)
+───────────────────────────────────────────────────────────────
+#1  2026-05-11T14:23:00Z  47 calls · 31.2% seen
+    Files (12):
+      src/cli.rs
+      src/parser/mod.rs
+      src/parser/rust.rs
+      src/symbols/mod.rs
+      ... (8 more)
+    Summary: "The user is building a CLI parser. Files modified:
+      src/parser/mod.rs, src/cli.rs. Next step: add flag validation..."
+
+#2  2026-05-11T15:41:00Z  89 calls · 58.0% seen
+    Files (28):
+      src/coverage.rs
+      src/ingest/claude.rs
+      ...
+    Summary: "Work continued on the CLI parser. TypeScript support added..."
+```
+
+Show the first 10 file paths then `... (N more)`. Wrap summary text at 80 chars with a hanging indent.
+
+### JSON formatter output
+
+Bump `schema_version` from `1` → `2`. Add `compactions` array (always present, empty when none):
+
+```json
+{
+  "schema_version": 2,
+  "session_id": "abc123",
+  "agent_id": null,
+  "totals": { "symbols": 142, "seen": 87, "full": 23, "seen_percent": 61.3, "full_percent": 16.2 },
+  "files": [ ... ],
+  "compactions": [
+    {
+      "sequence": 1,
+      "timestamp": "2026-05-11T14:23:00Z",
+      "summary": "The user is building a CLI parser...",
+      "state_before": {
+        "tool_calls": 47,
+        "files_accessed": [
+          "src/cli.rs",
+          "src/parser/mod.rs",
+          "src/parser/rust.rs",
+          "src/symbols/mod.rs"
+        ],
+        "symbols_seen": 31,
+        "seen_percent": 31.2
+      }
+    }
+  ]
+}
+```
+
+Use a `state_before` nested object so future fields (e.g. `token_count_before`) slot in cleanly.
+
+---
+
+## Implementation Order
+
+Work in this sequence — each step compiles and passes tests before starting the next:
+
+1. `src/ingest/claude.rs` — detect `type:"compaction"` blocks; add `ParsedLine::Compacted`; add unit test
+2. `src/ingest/mod.rs` — add `SessionEvent`, `LedgerSnapshot`, `CompactionEvent`; update trait signatures
+3. `src/ingest/claude.rs` — update `parse_log_file_with_mapper` to emit `SessionEvent::Compacted` in order
+4. `src/events.rs` — add `AppEvent::Compacted`
+5. `src/app.rs` — add `compaction_history`, `compaction_call_count`, `process_compaction()`; update `process_agent_event` and `reset_session`; update event dispatch callers
+6. `src/main.rs` + `src/tui.rs` — update to match on `SessionEvent`
+7. `src/ui/activity.rs` — render compaction marker in feed
+8. `src/ui/compaction.rs` — new diff overlay panel; wire `C` key in `handle_key`
+9. `src/ui/stats.rs` — add compaction count + last-compaction line
+10. `src/coverage.rs` — add `CompactionSummary`, extend `CoverageReport`, update `run_report` loop, update both formatters; bump JSON schema to v2; update tests
+
+---
+
+## What Does NOT Change
+
+- `ContextLedger` internal structure — no new fields or methods
+- `SymbolId` format
+- `agent-acompact-*` file exclusion — already correct
+- The `--coverage` CLI flag signature
+- Existing JSON consumers checking `schema_version == 1` should treat `2` as a superset
+
+---
+
+## Test Checklist
+
+- [ ] `parse_compaction_block_returns_compacted` — unit test in `claude.rs`
+- [ ] `parse_compact_command_returns_ignored` — existing test must still pass
+- [ ] `process_compaction_snapshots_files` — unit test in `app.rs`
+- [ ] `compaction_history_clears_on_reset_session` — unit test in `app.rs`
+- [ ] `coverage_report_includes_compaction_summary` — unit test in `coverage.rs`
+- [ ] `json_formatter_schema_version_2` — update existing schema_version test
+- [ ] `json_formatter_compaction_array_empty_when_none` — new test
+- [ ] `json_formatter_compaction_array_with_entries` — new test
+- [ ] `text_formatter_compaction_section_omitted_when_empty` — new test
+- [ ] `text_formatter_compaction_section_with_entries` — new test

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,6 +95,12 @@ pub struct App {
     pub session_id: Option<String>,
     pub session_slug: Option<String>,
 
+    // Compaction tracking.
+    pub compaction_history: Vec<crate::ingest::CompactionEvent>,
+    pub compaction_call_count: usize,
+    pub show_compaction_overlay: bool,
+    pub compaction_overlay_index: usize,
+
     // Optional event log writer.
     pub event_log: Option<BufWriter<File>>,
 }
@@ -128,6 +134,10 @@ impl App {
             search_query: String::new(),
             session_id: None,
             session_slug: None,
+            compaction_history: Vec::new(),
+            compaction_call_count: 0,
+            show_compaction_overlay: false,
+            compaction_overlay_index: 0,
             event_log,
         };
         app.rebuild_tree_rows();
@@ -145,7 +155,50 @@ impl App {
         self.agent_filter = None;
         self.agent_selection_index = 0;
         self.session_slug = None;
+        self.compaction_history.clear();
+        self.compaction_call_count = 0;
         self.rebuild_tree_rows();
+    }
+
+    /// Snapshot the current ledger state and record a compaction event.
+    pub fn process_compaction(
+        &mut self,
+        summary: String,
+        timestamp: String,
+        agent_id: std::sync::Arc<str>,
+    ) {
+        use std::collections::BTreeSet;
+        let files_before: BTreeSet<std::path::PathBuf> = self
+            .project_tree
+            .files
+            .iter()
+            .filter(|f| f.symbols.iter().any(|sym| self.ledger.depth_of(&sym.id).is_seen()))
+            .map(|f| f.file_path.clone())
+            .collect();
+
+        let total = self.project_tree.total_symbols();
+        let seen = self.ledger.total_seen();
+
+        let snapshot = crate::ingest::LedgerSnapshot {
+            tool_call_count: self.compaction_call_count,
+            files_accessed: files_before,
+            symbols_seen: seen,
+            seen_percent: if total > 0 {
+                seen as f64 / total as f64 * 100.0
+            } else {
+                0.0
+            },
+        };
+
+        let sequence = self.compaction_history.len() as u32 + 1;
+        self.compaction_history.push(crate::ingest::CompactionEvent {
+            sequence,
+            timestamp,
+            agent_id,
+            summary,
+            ledger_before: snapshot,
+        });
+        self.compaction_overlay_index = self.compaction_history.len().saturating_sub(1);
     }
 
     /// Rebuild the flattened tree rows from the project tree + collapsed state.
@@ -263,6 +316,21 @@ impl App {
             }
             KeyCode::Char('a') => self.cycle_agent_filter(),
             KeyCode::Char('A') => self.cycle_agent_filter_backward(),
+            KeyCode::Char('C') => {
+                if !self.compaction_history.is_empty() {
+                    self.show_compaction_overlay = !self.show_compaction_overlay;
+                }
+            }
+            KeyCode::Char('[') if self.show_compaction_overlay => {
+                if self.compaction_overlay_index > 0 {
+                    self.compaction_overlay_index -= 1;
+                }
+            }
+            KeyCode::Char(']') if self.show_compaction_overlay => {
+                if self.compaction_overlay_index + 1 < self.compaction_history.len() {
+                    self.compaction_overlay_index += 1;
+                }
+            }
             KeyCode::Tab => self.cycle_focus(),
             KeyCode::BackTab => self.cycle_agent_filter_backward(),
             KeyCode::PageDown => self.move_selection(20),
@@ -497,6 +565,7 @@ impl App {
 
     /// Process an agent tool call event and update the ledger.
     pub fn process_agent_event(&mut self, event: AgentToolCall) {
+        self.compaction_call_count += 1;
         // Track unique agents.
         if !self.agents_seen.iter().any(|a| a.as_str() == &*event.agent_id) {
             self.agents_seen.push(event.agent_id.to_string());

--- a/src/app.rs
+++ b/src/app.rs
@@ -160,7 +160,13 @@ impl App {
         self.rebuild_tree_rows();
     }
 
-    /// Snapshot the current ledger state and record a compaction event.
+    /// Snapshot the current ledger state, record a compaction event, then
+    /// clear the live ledger. The summary text doesn't reliably describe what
+    /// the model retained, so we drop all pre-compaction depth claims rather
+    /// than over-report coverage that may no longer reflect the model's
+    /// actual context. `compaction_history`, `activity`, and agent-tracking
+    /// state are preserved — only the live read-depth ledger and the
+    /// inter-compaction tool-call counter are reset.
     pub fn process_compaction(
         &mut self,
         summary: String,
@@ -201,6 +207,11 @@ impl App {
             metadata,
         });
         self.compaction_overlay_index = self.compaction_history.len().saturating_sub(1);
+
+        // Wipe the live ledger: post-compaction depth tracking starts fresh.
+        self.ledger = ContextLedger::new();
+        self.compaction_call_count = 0;
+        self.rebuild_tree_rows();
     }
 
     /// Rebuild the flattened tree rows from the project tree + collapsed state.
@@ -1391,6 +1402,62 @@ mod tests {
     }
 
     #[test]
+    fn process_compaction_clears_live_ledger() {
+        // Two files; read one. After compaction, the live ledger should be
+        // empty (symbol back to Unseen) but the snapshot captures the prior state.
+        let mut app = test_app(vec![
+            file("mock/a.rs", vec![sym("mock/a.rs::a1", "a1")]),
+        ]);
+        let event = tool_call("Read", "/test/project/mock/a.rs", ReadDepth::FullBody);
+        app.process_agent_event(event);
+
+        assert_eq!(app.ledger.depth_of("mock/a.rs::a1"), ReadDepth::FullBody);
+        assert_eq!(app.compaction_call_count, 1);
+
+        app.process_compaction(
+            "summary".into(),
+            "2026-05-11T14:23:00Z".into(),
+            "agent-1".into(),
+            None,
+        );
+
+        // Compaction history records the pre-compaction state.
+        assert_eq!(app.compaction_history.len(), 1);
+        assert_eq!(app.compaction_history[0].ledger_before.symbols_seen, 1);
+        // Live ledger is wiped — the symbol is Unseen again.
+        assert_eq!(app.ledger.depth_of("mock/a.rs::a1"), ReadDepth::Unseen);
+        assert_eq!(app.ledger.total_seen(), 0);
+        assert_eq!(app.compaction_call_count, 0);
+    }
+
+    #[test]
+    fn post_compaction_tool_calls_rebuild_ledger() {
+        // After compaction wipes the ledger, subsequent tool calls populate
+        // a fresh ledger without touching compaction_history.
+        let mut app = test_app(vec![
+            file("mock/a.rs", vec![sym("mock/a.rs::a1", "a1")]),
+            file("mock/b.rs", vec![sym("mock/b.rs::b1", "b1")]),
+        ]);
+        app.process_agent_event(tool_call("Read", "/test/project/mock/a.rs", ReadDepth::FullBody));
+        app.process_compaction(
+            "first".into(),
+            "2026-05-11T14:23:00Z".into(),
+            "agent-1".into(),
+            None,
+        );
+
+        // Read a different file after compaction.
+        app.process_agent_event(tool_call("Read", "/test/project/mock/b.rs", ReadDepth::FullBody));
+
+        assert_eq!(app.compaction_history.len(), 1, "compaction history retained");
+        assert_eq!(app.ledger.depth_of("mock/a.rs::a1"), ReadDepth::Unseen,
+            "pre-compaction read should not survive");
+        assert_eq!(app.ledger.depth_of("mock/b.rs::b1"), ReadDepth::FullBody,
+            "post-compaction read should be reflected");
+        assert_eq!(app.compaction_call_count, 1, "counter restarted from zero after compaction");
+    }
+
+    #[test]
     fn compaction_history_clears_on_reset_session() {
         let mut app = test_app(vec![file("mock/a.rs", vec![sym("mock/a.rs::a", "a")])]);
         let event = tool_call("Read", "/test/project/mock/a.rs", ReadDepth::FullBody);
@@ -1402,7 +1469,6 @@ mod tests {
             None,
         );
         assert_eq!(app.compaction_history.len(), 1);
-        assert_eq!(app.compaction_call_count, 1);
 
         app.reset_session();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1352,6 +1352,61 @@ mod tests {
     }
 
     #[test]
+    fn process_compaction_snapshots_files() {
+        // Two files; touch one before triggering the compaction so the snapshot
+        // captures only that file.
+        let mut app = test_app(vec![
+            file("mock/a.rs", vec![sym("mock/a.rs::a1", "a1")]),
+            file("mock/b.rs", vec![sym("mock/b.rs::b1", "b1")]),
+        ]);
+
+        let event = tool_call("Read", "/test/project/mock/a.rs", ReadDepth::FullBody);
+        app.process_agent_event(event);
+
+        app.process_compaction(
+            "first compaction".into(),
+            "2026-05-11T14:23:00Z".into(),
+            "agent-1".into(),
+        );
+
+        assert_eq!(app.compaction_history.len(), 1);
+        let snapshot = &app.compaction_history[0];
+        assert_eq!(snapshot.sequence, 1);
+        assert_eq!(snapshot.summary, "first compaction");
+        assert_eq!(snapshot.timestamp, "2026-05-11T14:23:00Z");
+        assert_eq!(snapshot.ledger_before.tool_call_count, 1);
+        // mock/a.rs was touched → present; mock/b.rs untouched → absent.
+        assert!(snapshot
+            .ledger_before
+            .files_accessed
+            .contains(&std::path::PathBuf::from("mock/a.rs")));
+        assert!(!snapshot
+            .ledger_before
+            .files_accessed
+            .contains(&std::path::PathBuf::from("mock/b.rs")));
+        assert_eq!(snapshot.ledger_before.symbols_seen, 1);
+    }
+
+    #[test]
+    fn compaction_history_clears_on_reset_session() {
+        let mut app = test_app(vec![file("mock/a.rs", vec![sym("mock/a.rs::a", "a")])]);
+        let event = tool_call("Read", "/test/project/mock/a.rs", ReadDepth::FullBody);
+        app.process_agent_event(event);
+        app.process_compaction(
+            "summary".into(),
+            "2026-05-11T14:23:00Z".into(),
+            "agent-1".into(),
+        );
+        assert_eq!(app.compaction_history.len(), 1);
+        assert_eq!(app.compaction_call_count, 1);
+
+        app.reset_session();
+
+        assert!(app.compaction_history.is_empty());
+        assert_eq!(app.compaction_call_count, 0);
+    }
+
+    #[test]
     fn reset_session_clears_ledger_and_agents() {
         use crate::ingest::AgentToolCall;
         use crate::tracking::ReadDepth;

--- a/src/app.rs
+++ b/src/app.rs
@@ -166,6 +166,7 @@ impl App {
         summary: String,
         timestamp: String,
         agent_id: std::sync::Arc<str>,
+        metadata: Option<crate::ingest::CompactionMetadata>,
     ) {
         use std::collections::BTreeSet;
         let files_before: BTreeSet<std::path::PathBuf> = self
@@ -197,6 +198,7 @@ impl App {
             agent_id,
             summary,
             ledger_before: snapshot,
+            metadata,
         });
         self.compaction_overlay_index = self.compaction_history.len().saturating_sub(1);
     }
@@ -1367,6 +1369,7 @@ mod tests {
             "first compaction".into(),
             "2026-05-11T14:23:00Z".into(),
             "agent-1".into(),
+            None,
         );
 
         assert_eq!(app.compaction_history.len(), 1);
@@ -1396,6 +1399,7 @@ mod tests {
             "summary".into(),
             "2026-05-11T14:23:00Z".into(),
             "agent-1".into(),
+            None,
         );
         assert_eq!(app.compaction_history.len(), 1);
         assert_eq!(app.compaction_call_count, 1);

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -46,6 +46,15 @@ impl FileCoverage {
     }
 }
 
+/// Token/trigger metadata for a compaction event, when present in the log.
+#[derive(Debug, Clone, Serialize)]
+pub struct CompactionMetadataSummary {
+    pub trigger: String,
+    pub pre_tokens: u64,
+    pub post_tokens: u64,
+    pub duration_ms: u64,
+}
+
 /// Pre-compaction snapshot for a single context compaction event, intended for the
 /// coverage report. Files are stored as relative-path strings (sorted) so the
 /// summary remains stable in JSON output.
@@ -58,6 +67,9 @@ pub struct CompactionSummary {
     pub files_before: Vec<String>,
     pub symbols_seen_before: usize,
     pub seen_percent_before: f64,
+    /// Token counts and trigger from the `compact_boundary` system record.
+    /// `None` when the log predates that record format or it was malformed.
+    pub metadata: Option<CompactionMetadataSummary>,
 }
 
 /// Complete coverage report for a project.
@@ -300,6 +312,21 @@ fn append_compactions_section(output: &mut String, compactions: &[CompactionSumm
             "#{}  {}  {} calls · {:.1}% seen\n",
             c.sequence, c.timestamp, c.tool_calls_before, c.seen_percent_before,
         ));
+        if let Some(m) = &c.metadata {
+            let delta_pct = if m.pre_tokens > 0 {
+                100.0 * (m.post_tokens as f64 - m.pre_tokens as f64) / m.pre_tokens as f64
+            } else {
+                0.0
+            };
+            output.push_str(&format!(
+                "    Tokens: {} → {} ({:+.1}%) · trigger: {} · {:.1}s\n",
+                m.pre_tokens,
+                m.post_tokens,
+                delta_pct,
+                m.trigger,
+                m.duration_ms as f64 / 1000.0,
+            ));
+        }
         output.push_str(&format!("    Files ({}):\n", c.files_before.len()));
         for path in c.files_before.iter().take(MAX_FILES_SHOWN) {
             output.push_str(&format!("      {path}\n"));
@@ -398,11 +425,21 @@ impl CoverageFormatter for JsonFormatter {
         }
 
         #[derive(Serialize)]
+        struct MetadataDto<'a> {
+            trigger: &'a str,
+            pre_tokens: u64,
+            post_tokens: u64,
+            duration_ms: u64,
+        }
+
+        #[derive(Serialize)]
         struct CompactionDto<'a> {
             sequence: u32,
             timestamp: &'a str,
             summary: &'a str,
             state_before: StateBeforeDto<'a>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            metadata: Option<MetadataDto<'a>>,
         }
 
         #[derive(Serialize)]
@@ -451,6 +488,12 @@ impl CoverageFormatter for JsonFormatter {
                         symbols_seen: c.symbols_seen_before,
                         seen_percent: c.seen_percent_before,
                     },
+                    metadata: c.metadata.as_ref().map(|m| MetadataDto {
+                        trigger: &m.trigger,
+                        pre_tokens: m.pre_tokens,
+                        post_tokens: m.post_tokens,
+                        duration_ms: m.duration_ms,
+                    }),
                 })
                 .collect(),
         };
@@ -519,7 +562,7 @@ pub fn run_report(
                             }
                         }
                     }
-                    SessionEvent::Compacted { summary, timestamp, .. } => {
+                    SessionEvent::Compacted { summary, timestamp, metadata, .. } => {
                         let seen = ledger.total_seen();
                         let total = project_tree.total_symbols();
                         compactions.push(CompactionSummary {
@@ -537,6 +580,12 @@ pub fn run_report(
                             } else {
                                 0.0
                             },
+                            metadata: metadata.map(|m| CompactionMetadataSummary {
+                                trigger: m.trigger,
+                                pre_tokens: m.pre_tokens,
+                                post_tokens: m.post_tokens,
+                                duration_ms: m.duration_ms,
+                            }),
                         });
                     }
                     SessionEvent::SessionCleared => {
@@ -823,7 +872,19 @@ mod tests {
             ],
             symbols_seen_before: 31,
             seen_percent_before: 31.2,
+            metadata: None,
         }
+    }
+
+    fn sample_compaction_with_metadata() -> CompactionSummary {
+        let mut c = sample_compaction();
+        c.metadata = Some(CompactionMetadataSummary {
+            trigger: "manual".to_string(),
+            pre_tokens: 195684,
+            post_tokens: 6416,
+            duration_ms: 64699,
+        });
+        c
     }
 
     #[test]
@@ -893,5 +954,41 @@ mod tests {
         let files = state["files_accessed"].as_array().unwrap();
         assert_eq!(files.len(), 2);
         assert_eq!(files[0], "src/cli.rs");
+        // `metadata` is absent (skip_serializing_if = "Option::is_none") when None.
+        assert!(entry.get("metadata").is_none(),
+            "metadata field should be omitted when None, got entry: {entry}");
+    }
+
+    #[test]
+    fn text_formatter_includes_token_metadata_line() {
+        let report = CoverageReport {
+            session_id: Some("s".into()),
+            agent_id: None,
+            files: vec![],
+            compactions: vec![sample_compaction_with_metadata()],
+        };
+        let output = TextFormatter::default().format(&report);
+        assert!(output.contains("Tokens: 195684"));
+        assert!(output.contains("6416"));
+        assert!(output.contains("trigger: manual"));
+        assert!(output.contains("64.7s"));
+    }
+
+    #[test]
+    fn json_formatter_includes_metadata_block() {
+        let report = CoverageReport {
+            session_id: Some("s".into()),
+            agent_id: None,
+            files: vec![],
+            compactions: vec![sample_compaction_with_metadata()],
+        };
+        let output = JsonFormatter.format(&report);
+        let value: serde_json::Value =
+            serde_json::from_str(output.trim()).expect("output must be valid JSON");
+        let metadata = &value["compactions"][0]["metadata"];
+        assert_eq!(metadata["trigger"], "manual");
+        assert_eq!(metadata["pre_tokens"], 195684);
+        assert_eq!(metadata["post_tokens"], 6416);
+        assert_eq!(metadata["duration_ms"], 64699);
     }
 }

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -46,6 +46,20 @@ impl FileCoverage {
     }
 }
 
+/// Pre-compaction snapshot for a single context compaction event, intended for the
+/// coverage report. Files are stored as relative-path strings (sorted) so the
+/// summary remains stable in JSON output.
+#[derive(Debug, Clone, Serialize)]
+pub struct CompactionSummary {
+    pub sequence: u32,
+    pub timestamp: String,
+    pub summary: String,
+    pub tool_calls_before: usize,
+    pub files_before: Vec<String>,
+    pub symbols_seen_before: usize,
+    pub seen_percent_before: f64,
+}
+
 /// Complete coverage report for a project.
 #[derive(Debug, Clone, Serialize)]
 pub struct CoverageReport {
@@ -55,6 +69,8 @@ pub struct CoverageReport {
     pub agent_id: Option<String>,
     /// Per-file coverage metrics.
     pub files: Vec<FileCoverage>,
+    /// Compactions detected in the session, in occurrence order. Empty when none.
+    pub compactions: Vec<CompactionSummary>,
 }
 
 impl CoverageReport {
@@ -91,6 +107,7 @@ impl CoverageReport {
             session_id: None,
             agent_id: agent_filter.map(|s| s.to_string()),
             files,
+            compactions: Vec::new(),
         }
     }
 
@@ -259,7 +276,86 @@ impl CoverageFormatter for TextFormatter {
             width = max_path_len
         ));
 
+        if !report.compactions.is_empty() {
+            append_compactions_section(&mut output, &report.compactions);
+        }
+
         output
+    }
+}
+
+/// Render the "Context Compactions" section after the TOTAL row. Caller must
+/// have already confirmed that `compactions` is non-empty.
+fn append_compactions_section(output: &mut String, compactions: &[CompactionSummary]) {
+    const MAX_FILES_SHOWN: usize = 10;
+    const SEP_WIDTH: usize = 63;
+    output.push('\n');
+    output.push_str(&format!("Context Compactions ({})\n", compactions.len()));
+    let separator: String = "─".repeat(SEP_WIDTH);
+    output.push_str(&separator);
+    output.push('\n');
+
+    for c in compactions {
+        output.push_str(&format!(
+            "#{}  {}  {} calls · {:.1}% seen\n",
+            c.sequence, c.timestamp, c.tool_calls_before, c.seen_percent_before,
+        ));
+        output.push_str(&format!("    Files ({}):\n", c.files_before.len()));
+        for path in c.files_before.iter().take(MAX_FILES_SHOWN) {
+            output.push_str(&format!("      {path}\n"));
+        }
+        if c.files_before.len() > MAX_FILES_SHOWN {
+            output.push_str(&format!(
+                "      ... ({} more)\n",
+                c.files_before.len() - MAX_FILES_SHOWN,
+            ));
+        }
+        append_wrapped_summary(output, &c.summary);
+        output.push('\n');
+    }
+}
+
+/// Append the summary text after a `Summary:` label, wrapping at 80 chars with
+/// a hanging indent so continuation lines line up under the first character of
+/// the summary text.
+fn append_wrapped_summary(output: &mut String, summary: &str) {
+    const LINE_WIDTH: usize = 80;
+    const INDENT_FIRST: &str = "    Summary: ";
+    const INDENT_CONT: &str = "      ";
+
+    let first_budget = LINE_WIDTH.saturating_sub(INDENT_FIRST.len());
+    let cont_budget = LINE_WIDTH.saturating_sub(INDENT_CONT.len());
+
+    let mut words = summary.split_whitespace().peekable();
+    let mut line = String::new();
+    let mut first = true;
+    while let Some(word) = words.next() {
+        let budget = if first { first_budget } else { cont_budget };
+        if line.is_empty() {
+            line.push_str(word);
+        } else if line.len() + 1 + word.len() > budget {
+            // Flush current line.
+            output.push_str(if first { INDENT_FIRST } else { INDENT_CONT });
+            output.push_str(&line);
+            output.push('\n');
+            line.clear();
+            line.push_str(word);
+            first = false;
+        } else {
+            line.push(' ');
+            line.push_str(word);
+        }
+        if words.peek().is_none() && !line.is_empty() {
+            output.push_str(if first { INDENT_FIRST } else { INDENT_CONT });
+            output.push_str(&line);
+            output.push('\n');
+            line.clear();
+        }
+    }
+    if line.is_empty() && first {
+        // Empty summary — still print the label so the structure is consistent.
+        output.push_str(INDENT_FIRST);
+        output.push('\n');
     }
 }
 
@@ -294,16 +390,33 @@ impl CoverageFormatter for JsonFormatter {
         }
 
         #[derive(Serialize)]
+        struct StateBeforeDto<'a> {
+            tool_calls: usize,
+            files_accessed: &'a [String],
+            symbols_seen: usize,
+            seen_percent: f64,
+        }
+
+        #[derive(Serialize)]
+        struct CompactionDto<'a> {
+            sequence: u32,
+            timestamp: &'a str,
+            summary: &'a str,
+            state_before: StateBeforeDto<'a>,
+        }
+
+        #[derive(Serialize)]
         struct ReportDto<'a> {
             schema_version: u32,
             session_id: Option<&'a str>,
             agent_id: Option<&'a str>,
             totals: Totals,
             files: Vec<FileDto<'a>>,
+            compactions: Vec<CompactionDto<'a>>,
         }
 
         let dto = ReportDto {
-            schema_version: 1,
+            schema_version: 2,
             session_id: report.session_id.as_deref(),
             agent_id: report.agent_id.as_deref(),
             totals: Totals {
@@ -323,6 +436,21 @@ impl CoverageFormatter for JsonFormatter {
                     full_count: f.full_count,
                     seen_percent: f.seen_percent(),
                     full_percent: f.full_percent(),
+                })
+                .collect(),
+            compactions: report
+                .compactions
+                .iter()
+                .map(|c| CompactionDto {
+                    sequence: c.sequence,
+                    timestamp: &c.timestamp,
+                    summary: &c.summary,
+                    state_before: StateBeforeDto {
+                        tool_calls: c.tool_calls_before,
+                        files_accessed: &c.files_before,
+                        symbols_seen: c.symbols_seen_before,
+                        seen_percent: c.seen_percent_before,
+                    },
                 })
                 .collect(),
         };
@@ -363,24 +491,59 @@ pub fn run_report(
     // 3. Build ledger from session logs.
     let mut ledger = ContextLedger::new();
     let mut known_agents: Vec<String> = Vec::new();
+    let mut files_accessed: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut tool_call_count: usize = 0;
+    let mut compactions: Vec<CompactionSummary> = Vec::new();
     if let (Some(ref log_dir), Some(ref sid)) = (&log_dir, &session_id) {
         let log_files = ingester.session_log_files(log_dir, sid);
         for log_file in &log_files {
-            let events = ingester.parse_log_file(log_file);
+            let events = ingester.parse_log_file_with_root(log_file, project_path);
             for event in events {
-                if !known_agents.iter().any(|a: &String| a.as_str() == &*event.agent_id) {
-                    known_agents.push(event.agent_id.to_string());
-                }
-                if let Some(ref file_path) = event.file_path {
-                    let tool_rel = crate::app::normalize_tool_path(file_path, project_path);
-                    for file in &project_tree.files {
-                        if file.file_path == tool_rel {
-                            if event.target_symbol.is_some() || event.target_lines.is_some() {
-                                crate::app::mark_targeted_symbols(&file.symbols, &event, &mut ledger);
-                            } else {
-                                crate::app::mark_file_symbols(&file.symbols, &event, &mut ledger);
+                match event {
+                    SessionEvent::ToolCall(tc) => {
+                        tool_call_count += 1;
+                        if !known_agents.iter().any(|a: &String| a.as_str() == &*tc.agent_id) {
+                            known_agents.push(tc.agent_id.to_string());
+                        }
+                        if let Some(ref file_path) = tc.file_path {
+                            let tool_rel = crate::app::normalize_tool_path(file_path, project_path);
+                            files_accessed.insert(tool_rel.clone());
+                            for file in &project_tree.files {
+                                if file.file_path == tool_rel {
+                                    if tc.target_symbol.is_some() || tc.target_lines.is_some() {
+                                        crate::app::mark_targeted_symbols(&file.symbols, &tc, &mut ledger);
+                                    } else {
+                                        crate::app::mark_file_symbols(&file.symbols, &tc, &mut ledger);
+                                    }
+                                }
                             }
                         }
+                    }
+                    SessionEvent::Compacted { summary, timestamp, .. } => {
+                        let seen = ledger.total_seen();
+                        let total = project_tree.total_symbols();
+                        compactions.push(CompactionSummary {
+                            sequence: compactions.len() as u32 + 1,
+                            timestamp,
+                            summary,
+                            tool_calls_before: tool_call_count,
+                            files_before: files_accessed
+                                .iter()
+                                .map(|p| p.to_string_lossy().into_owned())
+                                .collect(),
+                            symbols_seen_before: seen,
+                            seen_percent_before: if total > 0 {
+                                seen as f64 / total as f64 * 100.0
+                            } else {
+                                0.0
+                            },
+                        });
+                    }
+                    SessionEvent::SessionCleared => {
+                        ledger = ContextLedger::new();
+                        files_accessed.clear();
+                        tool_call_count = 0;
+                        compactions.clear();
                     }
                 }
             }
@@ -413,6 +576,7 @@ pub fn run_report(
     // 5. Generate and print report.
     let mut report = CoverageReport::from_project(project_tree, &ledger, resolved_agent.as_deref());
     report.session_id = session_id;
+    report.compactions = compactions;
 
     print!("{}", formatter.format(&report));
 
@@ -596,9 +760,17 @@ mod tests {
 
     #[test]
     fn text_formatter_output() {
-        let report = CoverageReport { session_id: Some("abc-123".into()), agent_id: None, files: vec![
-            FileCoverage { path: "src/main.rs".into(), total_symbols: 10, seen_count: 8, full_count: 5 },
-        ]};
+        let report = CoverageReport {
+            session_id: Some("abc-123".into()),
+            agent_id: None,
+            files: vec![FileCoverage {
+                path: "src/main.rs".into(),
+                total_symbols: 10,
+                seen_count: 8,
+                full_count: 5,
+            }],
+            compactions: Vec::new(),
+        };
         let formatter = TextFormatter::default();
         let output = formatter.format(&report);
         assert!(output.contains("Coverage Report (session: abc-123)"));
@@ -612,11 +784,12 @@ mod tests {
             session_id: Some("s".into()),
             agent_id: None,
             files: vec![],
+            compactions: Vec::new(),
         };
         let output = JsonFormatter.format(&report);
         let value: serde_json::Value =
             serde_json::from_str(output.trim()).expect("output must be valid JSON");
-        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["schema_version"], 2);
     }
 
     #[test]
@@ -630,10 +803,95 @@ mod tests {
                 seen_count: 1,
                 full_count: 1,
             }],
+            compactions: Vec::new(),
         };
         let output = JsonFormatter.format(&report);
         assert!(output.ends_with('\n'), "output must end with a trailing newline");
         let body = output.trim_end_matches('\n');
         assert!(!body.contains('\n'), "JSON body must be a single line");
+    }
+
+    fn sample_compaction() -> CompactionSummary {
+        CompactionSummary {
+            sequence: 1,
+            timestamp: "2026-05-11T14:23:00Z".to_string(),
+            summary: "The user is building a CLI parser. Files modified: src/parser/mod.rs, src/cli.rs. Next step: add flag validation.".to_string(),
+            tool_calls_before: 47,
+            files_before: vec![
+                "src/cli.rs".to_string(),
+                "src/parser/mod.rs".to_string(),
+            ],
+            symbols_seen_before: 31,
+            seen_percent_before: 31.2,
+        }
+    }
+
+    #[test]
+    fn text_formatter_compaction_section_omitted_when_empty() {
+        let report = CoverageReport {
+            session_id: Some("s".into()),
+            agent_id: None,
+            files: vec![],
+            compactions: Vec::new(),
+        };
+        let output = TextFormatter::default().format(&report);
+        assert!(!output.contains("Context Compactions"),
+            "compaction section must be absent when empty, got:\n{output}");
+    }
+
+    #[test]
+    fn text_formatter_compaction_section_with_entries() {
+        let report = CoverageReport {
+            session_id: Some("s".into()),
+            agent_id: None,
+            files: vec![],
+            compactions: vec![sample_compaction()],
+        };
+        let output = TextFormatter::default().format(&report);
+        assert!(output.contains("Context Compactions (1)"));
+        assert!(output.contains("#1"));
+        assert!(output.contains("47 calls"));
+        assert!(output.contains("src/cli.rs"));
+        assert!(output.contains("CLI parser"));
+    }
+
+    #[test]
+    fn json_formatter_compaction_array_empty_when_none() {
+        let report = CoverageReport {
+            session_id: Some("s".into()),
+            agent_id: None,
+            files: vec![],
+            compactions: Vec::new(),
+        };
+        let output = JsonFormatter.format(&report);
+        let value: serde_json::Value =
+            serde_json::from_str(output.trim()).expect("output must be valid JSON");
+        assert_eq!(value["schema_version"], 2);
+        assert!(value["compactions"].is_array());
+        assert_eq!(value["compactions"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn json_formatter_compaction_array_with_entries() {
+        let report = CoverageReport {
+            session_id: Some("s".into()),
+            agent_id: None,
+            files: vec![],
+            compactions: vec![sample_compaction()],
+        };
+        let output = JsonFormatter.format(&report);
+        let value: serde_json::Value =
+            serde_json::from_str(output.trim()).expect("output must be valid JSON");
+        let arr = value["compactions"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let entry = &arr[0];
+        assert_eq!(entry["sequence"], 1);
+        assert_eq!(entry["timestamp"], "2026-05-11T14:23:00Z");
+        let state = &entry["state_before"];
+        assert_eq!(state["tool_calls"], 47);
+        assert_eq!(state["symbols_seen"], 31);
+        let files = state["files_accessed"].as_array().unwrap();
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0], "src/cli.rs");
     }
 }

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -3,11 +3,13 @@
 //! This module provides structures and formatters for generating coverage reports
 //! that show how much of a project's symbols have been seen by an LLM agent.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::Result;
 use serde::Serialize;
 
+use crate::ingest::SessionEvent;
 use crate::symbols::{ProjectTree, SymbolNode};
 use crate::tracking::{ContextLedger, ReadDepth};
 

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -587,6 +587,12 @@ pub fn run_report(
                                 duration_ms: m.duration_ms,
                             }),
                         });
+                        // Mirror `App::process_compaction`: wipe live depth state
+                        // so the final coverage report reflects post-compaction
+                        // context only. `compactions` is preserved.
+                        ledger = ContextLedger::new();
+                        files_accessed.clear();
+                        tool_call_count = 0;
                     }
                     SessionEvent::SessionCleared => {
                         ledger = ContextLedger::new();

--- a/src/events.rs
+++ b/src/events.rs
@@ -13,6 +13,7 @@ pub enum AppEvent {
     FileChanged(PathBuf),
     AgentEvent(AgentToolCall),
     SessionCleared,
+    Compacted(ambits::ingest::CompactionEvent),
     Tick,
 }
 

--- a/src/ingest/claude.rs
+++ b/src/ingest/claude.rs
@@ -93,14 +93,24 @@ fn is_uuid(s: &str) -> bool {
 /// (the main session file + any agent-*.jsonl files that reference it).
 /// Supports both old format (agent files flat in log dir) and new format
 /// (agent files in `<session-id>/subagents/`).
+///
+/// **Ordering:** subagent files first, main session file last. Callers
+/// (`coverage::run_report`, the TUI pre-populate loop) replay each file
+/// end-to-end before the next, so events are not globally timestamp-sorted.
+/// Putting the main session file last means any compaction in it — which now
+/// clears the ledger — fires after subagent work has been accumulated, so
+/// pre-compaction subagent reads survive into the post-compaction snapshot
+/// rather than being wiped by an out-of-order compaction.
+///
+/// Residual risk: a subagent whose work runs *concurrently with* and finishes
+/// *after* the main session's compaction will still have its post-compaction
+/// reads wiped when we process the main file later and replay the
+/// compaction. Strictly correct ordering would require a cross-file
+/// timestamp merge; that's deferred. In practice, subagents almost always
+/// complete before the main session reaches the token threshold for a
+/// compaction, so this heuristic covers the common case.
 pub fn session_log_files(log_dir: &Path, session_id: &str) -> Vec<PathBuf> {
     let mut files = Vec::new();
-
-    // Main session file.
-    let main_file = log_dir.join(format!("{session_id}.jsonl"));
-    if main_file.exists() {
-        files.push(main_file);
-    }
 
     // New format: <log_dir>/<session-id>/subagents/agent-*.jsonl
     // All files in this directory belong to the session by definition.
@@ -139,6 +149,13 @@ pub fn session_log_files(log_dir: &Path, session_id: &str) -> Vec<PathBuf> {
                 files.push(path);
             }
         }
+    }
+
+    // Main session file last — its compaction events clear the ledger, so
+    // we want subagent events accumulated first.
+    let main_file = log_dir.join(format!("{session_id}.jsonl"));
+    if main_file.exists() {
+        files.push(main_file);
     }
 
     files

--- a/src/ingest/claude.rs
+++ b/src/ingest/claude.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use crate::tracking::ReadDepth;
-use super::{AgentToolCall, EventTailer, SessionEvent, SessionIngester, TailerOutput, ToolCallMapper};
+use super::{AgentToolCall, EventTailer, SessionEvent, SessionIngester, TailedCompaction, TailerOutput, ToolCallMapper};
 use super::tool_config::ToolMappingConfig;
 
 /// Derive the Claude Code log directory for a given project path.
@@ -359,8 +359,23 @@ pub fn parse_jsonl_line(line: &str, default_agent_id: &str, mapper: &dyn ToolCal
 
     let msg_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
-    // Detect /clear command in user messages.
+    // Detect compaction summary and /clear command in user messages.
     if msg_type == "user" {
+        // Claude Code emits the post-compaction summary as a `type:"user"` record
+        // with `isCompactSummary:true`. The `message.content` is a plain string.
+        if obj.get("isCompactSummary").and_then(|v| v.as_bool()) == Some(true) {
+            let summary = obj
+                .pointer("/message/content")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let timestamp = obj
+                .get("timestamp")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            return ParsedLine::Compacted { summary, timestamp };
+        }
         let content = obj
             .pointer("/message/content")
             .and_then(|v| v.as_str())
@@ -393,19 +408,6 @@ pub fn parse_jsonl_line(line: &str, default_agent_id: &str, mapper: &dyn ToolCal
         Some(Value::Array(arr)) => arr,
         _ => return ParsedLine::Ignored,
     };
-
-    // Compaction blocks are mutually exclusive with tool_use in practice;
-    // scan for one before entering the tool-use loop.
-    for block in content {
-        if block.get("type").and_then(|v| v.as_str()) == Some("compaction") {
-            let summary = block
-                .get("content")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            return ParsedLine::Compacted { summary, timestamp: timestamp_str };
-        }
-    }
 
     let mut events = Vec::new();
     for block in content {
@@ -671,6 +673,7 @@ impl LogTailer {
     pub fn read_new_events(&mut self) -> TailerOutput {
         let mut output = TailerOutput {
             events: Vec::new(),
+            compactions: Vec::new(),
             session_cleared: false,
         };
 
@@ -704,7 +707,13 @@ impl LogTailer {
                             Ok(_) => match parse_jsonl_line(line.trim(), &default_id, &*self.mapper) {
                                 ParsedLine::Events(events) => output.events.extend(events),
                                 ParsedLine::SessionCleared => output.session_cleared = true,
-                                ParsedLine::Compacted { .. } => {}
+                                ParsedLine::Compacted { summary, timestamp } => {
+                                    output.compactions.push(TailedCompaction {
+                                        summary,
+                                        timestamp,
+                                        agent_id: Arc::from(default_id.as_str()),
+                                    });
+                                }
                                 ParsedLine::Ignored => {}
                             },
                             Err(_) => break,
@@ -1528,15 +1537,51 @@ description  = "UserTool {target}"
     }
 
     #[test]
-    fn parse_compaction_block_returns_compacted() {
-        let line = r#"{"type":"assistant","sessionId":"abc","timestamp":"2026-05-11T14:23:00Z","message":{"role":"assistant","content":[{"type":"compaction","content":"Summary of the conversation: The user is building a CLI parser."},{"type":"text","text":"Based on our conversation so far..."}]}}"#;
+    fn parse_is_compact_summary_user_record_returns_compacted() {
+        // Real Claude Code (v2.1.132) shape: a `type:"user"` record with
+        // `isCompactSummary:true` carries the summary in `message.content` (string).
+        let line = r#"{"type":"user","sessionId":"abc","timestamp":"2026-05-11T20:59:25.329Z","isVisibleInTranscriptOnly":true,"isCompactSummary":true,"message":{"role":"user","content":"Summary of the conversation: The user is building a CLI parser."}}"#;
         let config = ToolMappingConfig::builtin().expect("builtin config");
         match parse_jsonl_line(line, "default", &config) {
             ParsedLine::Compacted { summary, timestamp } => {
-                assert!(summary.contains("CLI parser"), "summary should contain compaction text");
-                assert_eq!(timestamp, "2026-05-11T14:23:00Z");
+                assert!(summary.contains("CLI parser"), "summary should contain compaction text, got: {summary:?}");
+                assert_eq!(timestamp, "2026-05-11T20:59:25.329Z");
             }
-            _ => panic!("expected ParsedLine::Compacted"),
+            other => panic!("expected ParsedLine::Compacted, got {:?}", match other {
+                ParsedLine::Events(_) => "Events",
+                ParsedLine::Compacted { .. } => "Compacted",
+                ParsedLine::SessionCleared => "SessionCleared",
+                ParsedLine::Ignored => "Ignored",
+            }),
         }
+    }
+
+    #[test]
+    fn parse_is_compact_summary_does_not_trigger_session_cleared() {
+        // The summary content can mention `/clear` in prose; isCompactSummary
+        // must take precedence over the `<command-name>/clear</command-name>` heuristic.
+        let line = r#"{"type":"user","isCompactSummary":true,"timestamp":"2026-05-11T21:00:00Z","message":{"role":"user","content":"User ran <command-name>/clear</command-name> earlier in the session"}}"#;
+        let config = ToolMappingConfig::builtin().expect("builtin config");
+        assert!(matches!(
+            parse_jsonl_line(line, "d", &config),
+            ParsedLine::Compacted { .. }
+        ));
+    }
+
+    #[test]
+    fn tailer_emits_compactions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("session.jsonl");
+        fs::write(&log, "").unwrap();
+        let config: Arc<dyn ToolCallMapper> = Arc::new(ToolMappingConfig::builtin().unwrap());
+        let mut tailer = LogTailer::new(vec![log.clone()], config);
+
+        let compact_line = r#"{"type":"user","sessionId":"abc","timestamp":"2026-05-11T20:59:25.329Z","isCompactSummary":true,"message":{"role":"user","content":"This session is being continued from a previous conversation."}}"#;
+        fs::write(&log, format!("{compact_line}\n")).unwrap();
+
+        let output = tailer.read_new_events();
+        assert_eq!(output.compactions.len(), 1);
+        assert!(output.compactions[0].summary.contains("being continued"));
+        assert_eq!(output.compactions[0].timestamp, "2026-05-11T20:59:25.329Z");
     }
 }

--- a/src/ingest/claude.rs
+++ b/src/ingest/claude.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use crate::tracking::ReadDepth;
-use super::{AgentToolCall, EventTailer, SessionIngester, TailerOutput, ToolCallMapper};
+use super::{AgentToolCall, EventTailer, SessionEvent, SessionIngester, TailerOutput, ToolCallMapper};
 use super::tool_config::ToolMappingConfig;
 
 /// Derive the Claude Code log directory for a given project path.
@@ -258,14 +258,13 @@ pub fn extract_agent_label(path: &Path) -> String {
 /// The result of parsing a single JSONL line.
 pub enum ParsedLine {
     Events(Vec<AgentToolCall>),
+    Compacted { summary: String, timestamp: String },
     SessionCleared,
     Ignored,
 }
 
 /// Parse all events from a JSONL log file.
-/// SessionCleared signals are ignored in batch mode — dump/coverage modes show
-/// aggregate historical coverage, not live session state.
-pub fn parse_log_file(path: &Path, config: &ToolMappingConfig) -> Vec<AgentToolCall> {
+pub fn parse_log_file(path: &Path, config: &ToolMappingConfig) -> Vec<SessionEvent> {
     parse_log_file_with_mapper(path, config, None)
 }
 
@@ -273,8 +272,8 @@ fn parse_log_file_with_mapper(
     path: &Path,
     mapper: &dyn ToolCallMapper,
     project_root: Option<&Path>,
-) -> Vec<AgentToolCall> {
-    let mut events = Vec::new();
+) -> Vec<SessionEvent> {
+    let mut events: Vec<SessionEvent> = Vec::new();
     let file = match fs::File::open(path) {
         Ok(f) => f,
         Err(_) => return events,
@@ -323,20 +322,28 @@ fn parse_log_file_with_mapper(
     let _ = reader.seek(SeekFrom::Start(0));
 
     for line in reader.lines().map_while(Result::ok) {
-        if let ParsedLine::Events(mut line_events) =
-            parse_jsonl_line(line.trim(), &default_id, mapper)
-        {
-            if let Some((ref worktree, ref project)) = cwd_remap {
-                for ev in &mut line_events {
-                    if let Some(ref fp) = ev.file_path {
-                        ev.file_path = Some(remap_path(fp, worktree, project));
+        match parse_jsonl_line(line.trim(), &default_id, mapper) {
+            ParsedLine::Events(mut line_events) => {
+                if let Some((ref worktree, ref project)) = cwd_remap {
+                    for ev in &mut line_events {
+                        if let Some(ref fp) = ev.file_path {
+                            ev.file_path = Some(remap_path(fp, worktree, project));
+                        }
                     }
                 }
+                for ev in &mut line_events {
+                    ev.label = label.clone();
+                }
+                events.extend(line_events.into_iter().map(SessionEvent::ToolCall));
             }
-            for ev in &mut line_events {
-                ev.label = label.clone();
+            ParsedLine::Compacted { summary, timestamp } => {
+                let agent_id: Arc<str> = Arc::from(default_id.as_str());
+                events.push(SessionEvent::Compacted { summary, timestamp, agent_id });
             }
-            events.extend(line_events);
+            ParsedLine::SessionCleared => {
+                events.push(SessionEvent::SessionCleared);
+            }
+            ParsedLine::Ignored => {}
         }
     }
     events
@@ -386,6 +393,19 @@ pub fn parse_jsonl_line(line: &str, default_agent_id: &str, mapper: &dyn ToolCal
         Some(Value::Array(arr)) => arr,
         _ => return ParsedLine::Ignored,
     };
+
+    // Compaction blocks are mutually exclusive with tool_use in practice;
+    // scan for one before entering the tool-use loop.
+    for block in content {
+        if block.get("type").and_then(|v| v.as_str()) == Some("compaction") {
+            let summary = block
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            return ParsedLine::Compacted { summary, timestamp: timestamp_str };
+        }
+    }
 
     let mut events = Vec::new();
     for block in content {
@@ -684,6 +704,7 @@ impl LogTailer {
                             Ok(_) => match parse_jsonl_line(line.trim(), &default_id, &*self.mapper) {
                                 ParsedLine::Events(events) => output.events.extend(events),
                                 ParsedLine::SessionCleared => output.session_cleared = true,
+                                ParsedLine::Compacted { .. } => {}
                                 ParsedLine::Ignored => {}
                             },
                             Err(_) => break,
@@ -727,10 +748,10 @@ impl SessionIngester for ClaudeIngester {
     fn session_log_files(&self, log_dir: &Path, session_id: &str) -> Vec<PathBuf> {
         session_log_files(log_dir, session_id)
     }
-    fn parse_log_file(&self, path: &Path) -> Vec<AgentToolCall> {
+    fn parse_log_file(&self, path: &Path) -> Vec<SessionEvent> {
         parse_log_file_with_mapper(path, &*self.mapper, None)
     }
-    fn parse_log_file_with_root(&self, path: &Path, project_root: &Path) -> Vec<AgentToolCall> {
+    fn parse_log_file_with_root(&self, path: &Path, project_root: &Path) -> Vec<SessionEvent> {
         parse_log_file_with_mapper(path, &*self.mapper, Some(project_root))
     }
     fn session_slug(&self, log_dir: &Path, session_id: &str) -> Option<String> {
@@ -1136,7 +1157,11 @@ mod tests {
         let config = ToolMappingConfig::builtin().unwrap();
         let events = parse_log_file(&log, &config);
         assert_eq!(events.len(), 1);
-        assert_eq!(&*events[0].label, "Check the coverage");
+        if let SessionEvent::ToolCall(ref tc) = events[0] {
+            assert_eq!(&*tc.label, "Check the coverage");
+        } else {
+            panic!("expected ToolCall event");
+        }
     }
 
     #[test]
@@ -1411,10 +1436,11 @@ description  = "UserTool {target}"
         let config = ToolMappingConfig::builtin().unwrap();
         let events = parse_log_file_with_mapper(&log, &config, Some(&project));
         assert_eq!(events.len(), 1);
-        assert_eq!(
-            events[0].file_path.as_ref().unwrap(),
-            &project.join("src/main.rs"),
-        );
+        if let SessionEvent::ToolCall(ref tc) = events[0] {
+            assert_eq!(tc.file_path.as_ref().unwrap(), &project.join("src/main.rs"));
+        } else {
+            panic!("expected ToolCall event");
+        }
     }
 
     #[test]
@@ -1435,10 +1461,11 @@ description  = "UserTool {target}"
         let config = ToolMappingConfig::builtin().unwrap();
         let events = parse_log_file_with_mapper(&log, &config, Some(&project));
         assert_eq!(events.len(), 1);
-        assert_eq!(
-            events[0].file_path.as_ref().unwrap(),
-            &project.join("src/main.rs"),
-        );
+        if let SessionEvent::ToolCall(ref tc) = events[0] {
+            assert_eq!(tc.file_path.as_ref().unwrap(), &project.join("src/main.rs"));
+        } else {
+            panic!("expected ToolCall event");
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1498,5 +1525,18 @@ description  = "UserTool {target}"
     #[test]
     fn bash_bfs_gets_name_only() {
         assert_eq!(bash_event("bfs . -name '*.rs'").read_depth, ReadDepth::NameOnly);
+    }
+
+    #[test]
+    fn parse_compaction_block_returns_compacted() {
+        let line = r#"{"type":"assistant","sessionId":"abc","timestamp":"2026-05-11T14:23:00Z","message":{"role":"assistant","content":[{"type":"compaction","content":"Summary of the conversation: The user is building a CLI parser."},{"type":"text","text":"Based on our conversation so far..."}]}}"#;
+        let config = ToolMappingConfig::builtin().expect("builtin config");
+        match parse_jsonl_line(line, "default", &config) {
+            ParsedLine::Compacted { summary, timestamp } => {
+                assert!(summary.contains("CLI parser"), "summary should contain compaction text");
+                assert_eq!(timestamp, "2026-05-11T14:23:00Z");
+            }
+            _ => panic!("expected ParsedLine::Compacted"),
+        }
     }
 }

--- a/src/ingest/claude.rs
+++ b/src/ingest/claude.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use crate::tracking::ReadDepth;
-use super::{AgentToolCall, EventTailer, SessionEvent, SessionIngester, TailedCompaction, TailerOutput, ToolCallMapper};
+use super::{AgentToolCall, CompactionMetadata, EventTailer, SessionEvent, SessionIngester, TailedCompaction, TailerOutput, ToolCallMapper};
 use super::tool_config::ToolMappingConfig;
 
 /// Derive the Claude Code log directory for a given project path.
@@ -258,7 +258,13 @@ pub fn extract_agent_label(path: &Path) -> String {
 /// The result of parsing a single JSONL line.
 pub enum ParsedLine {
     Events(Vec<AgentToolCall>),
+    /// `type:"user", isCompactSummary:true` — carries the post-compaction summary text.
     Compacted { summary: String, timestamp: String },
+    /// `type:"system", subtype:"compact_boundary"` — carries token metadata.
+    /// In Claude Code logs this record always precedes the `Compacted` record by
+    /// one line, so callers buffer the metadata and attach it to the next
+    /// `Compacted` event.
+    CompactBoundary { metadata: CompactionMetadata, timestamp: String },
     SessionCleared,
     Ignored,
 }
@@ -321,6 +327,11 @@ fn parse_log_file_with_mapper(
     // Seek back to start so all lines — including line 1 — are processed for events.
     let _ = reader.seek(SeekFrom::Start(0));
 
+    // Buffer the most-recent compact_boundary record. Claude Code emits the
+    // boundary immediately before the corresponding `isCompactSummary` line, so
+    // we attach the buffered metadata to the next `Compacted` event we see.
+    let mut pending_metadata: Option<CompactionMetadata> = None;
+
     for line in reader.lines().map_while(Result::ok) {
         match parse_jsonl_line(line.trim(), &default_id, mapper) {
             ParsedLine::Events(mut line_events) => {
@@ -336,9 +347,17 @@ fn parse_log_file_with_mapper(
                 }
                 events.extend(line_events.into_iter().map(SessionEvent::ToolCall));
             }
+            ParsedLine::CompactBoundary { metadata, .. } => {
+                pending_metadata = Some(metadata);
+            }
             ParsedLine::Compacted { summary, timestamp } => {
                 let agent_id: Arc<str> = Arc::from(default_id.as_str());
-                events.push(SessionEvent::Compacted { summary, timestamp, agent_id });
+                events.push(SessionEvent::Compacted {
+                    summary,
+                    timestamp,
+                    agent_id,
+                    metadata: pending_metadata.take(),
+                });
             }
             ParsedLine::SessionCleared => {
                 events.push(SessionEvent::SessionCleared);
@@ -347,6 +366,19 @@ fn parse_log_file_with_mapper(
         }
     }
     events
+}
+
+/// Parse the `compactMetadata` block from a `compact_boundary` system record.
+/// Returns None if any required field is missing or wrong-typed — `trigger` is
+/// required, token counts and duration default to 0 when absent.
+fn parse_compact_metadata(meta: &Value) -> Option<CompactionMetadata> {
+    let trigger = meta.get("trigger").and_then(|v| v.as_str())?.to_string();
+    Some(CompactionMetadata {
+        trigger,
+        pre_tokens: meta.get("preTokens").and_then(|v| v.as_u64()).unwrap_or(0),
+        post_tokens: meta.get("postTokens").and_then(|v| v.as_u64()).unwrap_or(0),
+        duration_ms: meta.get("durationMs").and_then(|v| v.as_u64()).unwrap_or(0),
+    })
 }
 
 /// Parse a single JSONL line from a Claude Code session log.
@@ -358,6 +390,22 @@ pub fn parse_jsonl_line(line: &str, default_agent_id: &str, mapper: &dyn ToolCal
     };
 
     let msg_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Detect the compaction boundary marker (precedes the summary by one line).
+    if msg_type == "system"
+        && obj.get("subtype").and_then(|v| v.as_str()) == Some("compact_boundary")
+    {
+        let timestamp = obj
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let metadata = obj.get("compactMetadata").and_then(parse_compact_metadata);
+        return match metadata {
+            Some(metadata) => ParsedLine::CompactBoundary { metadata, timestamp },
+            None => ParsedLine::Ignored,
+        };
+    }
 
     // Detect compaction summary and /clear command in user messages.
     if msg_type == "user" {
@@ -641,6 +689,10 @@ pub struct LogTailer {
     files: Vec<PathBuf>,
     positions: std::collections::HashMap<PathBuf, u64>,
     mapper: Arc<dyn ToolCallMapper>,
+    /// Most-recent `compact_boundary` metadata, held until the matching
+    /// `isCompactSummary` line arrives (usually within the same poll, but kept
+    /// across polls in case the writer flushes them separately).
+    pending_metadata: Option<CompactionMetadata>,
 }
 
 impl LogTailer {
@@ -654,7 +706,7 @@ impl LogTailer {
                 positions.insert(f.clone(), meta.len());
             }
         }
-        Self { files, positions, mapper }
+        Self { files, positions, mapper, pending_metadata: None }
     }
 
 
@@ -707,11 +759,15 @@ impl LogTailer {
                             Ok(_) => match parse_jsonl_line(line.trim(), &default_id, &*self.mapper) {
                                 ParsedLine::Events(events) => output.events.extend(events),
                                 ParsedLine::SessionCleared => output.session_cleared = true,
+                                ParsedLine::CompactBoundary { metadata, .. } => {
+                                    self.pending_metadata = Some(metadata);
+                                }
                                 ParsedLine::Compacted { summary, timestamp } => {
                                     output.compactions.push(TailedCompaction {
                                         summary,
                                         timestamp,
                                         agent_id: Arc::from(default_id.as_str()),
+                                        metadata: self.pending_metadata.take(),
                                     });
                                 }
                                 ParsedLine::Ignored => {}
@@ -1550,6 +1606,7 @@ description  = "UserTool {target}"
             other => panic!("expected ParsedLine::Compacted, got {:?}", match other {
                 ParsedLine::Events(_) => "Events",
                 ParsedLine::Compacted { .. } => "Compacted",
+                ParsedLine::CompactBoundary { .. } => "CompactBoundary",
                 ParsedLine::SessionCleared => "SessionCleared",
                 ParsedLine::Ignored => "Ignored",
             }),
@@ -1583,5 +1640,99 @@ description  = "UserTool {target}"
         assert_eq!(output.compactions.len(), 1);
         assert!(output.compactions[0].summary.contains("being continued"));
         assert_eq!(output.compactions[0].timestamp, "2026-05-11T20:59:25.329Z");
+    }
+
+    // -----------------------------------------------------------------------
+    // compact_boundary metadata parsing & pairing tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_compact_boundary_returns_metadata() {
+        let line = r#"{"type":"system","subtype":"compact_boundary","timestamp":"2026-05-11T20:59:25.328Z","compactMetadata":{"trigger":"manual","preTokens":195684,"postTokens":6416,"durationMs":64699}}"#;
+        let config = ToolMappingConfig::builtin().unwrap();
+        match parse_jsonl_line(line, "d", &config) {
+            ParsedLine::CompactBoundary { metadata, timestamp } => {
+                assert_eq!(metadata.trigger, "manual");
+                assert_eq!(metadata.pre_tokens, 195684);
+                assert_eq!(metadata.post_tokens, 6416);
+                assert_eq!(metadata.duration_ms, 64699);
+                assert_eq!(timestamp, "2026-05-11T20:59:25.328Z");
+            }
+            _ => panic!("expected CompactBoundary"),
+        }
+    }
+
+    #[test]
+    fn parse_compact_boundary_missing_trigger_is_ignored() {
+        // No trigger → metadata is unparseable → record is dropped (not surfaced
+        // as a half-populated CompactBoundary).
+        let line = r#"{"type":"system","subtype":"compact_boundary","timestamp":"2026-05-11T20:59:25.328Z","compactMetadata":{"preTokens":100}}"#;
+        let config = ToolMappingConfig::builtin().unwrap();
+        assert!(matches!(parse_jsonl_line(line, "d", &config), ParsedLine::Ignored));
+    }
+
+    #[test]
+    fn parse_log_file_attaches_boundary_metadata_to_next_summary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("session.jsonl");
+        let boundary = r#"{"type":"system","subtype":"compact_boundary","timestamp":"2026-05-11T20:59:25.328Z","compactMetadata":{"trigger":"manual","preTokens":195684,"postTokens":6416,"durationMs":64699}}"#;
+        let summary = r#"{"type":"user","timestamp":"2026-05-11T20:59:25.329Z","isCompactSummary":true,"message":{"role":"user","content":"This session is being continued..."}}"#;
+        fs::write(&log, format!("{boundary}\n{summary}\n")).unwrap();
+
+        let config = ToolMappingConfig::builtin().unwrap();
+        let events = parse_log_file(&log, &config);
+        assert_eq!(events.len(), 1, "boundary should be folded into the summary");
+        match &events[0] {
+            SessionEvent::Compacted { metadata, summary, timestamp, .. } => {
+                let m = metadata.as_ref().expect("metadata should be attached");
+                assert_eq!(m.trigger, "manual");
+                assert_eq!(m.pre_tokens, 195684);
+                assert_eq!(m.post_tokens, 6416);
+                assert!(summary.contains("being continued"));
+                assert_eq!(timestamp, "2026-05-11T20:59:25.329Z");
+            }
+            _ => panic!("expected Compacted event"),
+        }
+    }
+
+    #[test]
+    fn parse_log_file_summary_without_boundary_has_no_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("session.jsonl");
+        let summary = r#"{"type":"user","timestamp":"2026-05-11T20:59:25.329Z","isCompactSummary":true,"message":{"role":"user","content":"Continuing..."}}"#;
+        fs::write(&log, format!("{summary}\n")).unwrap();
+
+        let config = ToolMappingConfig::builtin().unwrap();
+        let events = parse_log_file(&log, &config);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            SessionEvent::Compacted { metadata, .. } => assert!(metadata.is_none()),
+            _ => panic!("expected Compacted event"),
+        }
+    }
+
+    #[test]
+    fn tailer_pairs_boundary_with_summary_across_polls() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = tmp.path().join("session.jsonl");
+        fs::write(&log, "").unwrap();
+        let config: Arc<dyn ToolCallMapper> = Arc::new(ToolMappingConfig::builtin().unwrap());
+        let mut tailer = LogTailer::new(vec![log.clone()], config);
+
+        // Poll 1: only the boundary record arrives.
+        let boundary = r#"{"type":"system","subtype":"compact_boundary","timestamp":"2026-05-11T20:59:25.328Z","compactMetadata":{"trigger":"auto","preTokens":50000,"postTokens":5000,"durationMs":12345}}"#;
+        fs::write(&log, format!("{boundary}\n")).unwrap();
+        let out1 = tailer.read_new_events();
+        assert_eq!(out1.compactions.len(), 0, "boundary alone should not surface a compaction");
+
+        // Poll 2: the summary record arrives — metadata from the buffered
+        // boundary should be attached.
+        let summary = r#"{"type":"user","timestamp":"2026-05-11T20:59:25.329Z","isCompactSummary":true,"message":{"role":"user","content":"Continuing..."}}"#;
+        fs::write(&log, format!("{boundary}\n{summary}\n")).unwrap();
+        let out2 = tailer.read_new_events();
+        assert_eq!(out2.compactions.len(), 1);
+        let m = out2.compactions[0].metadata.as_ref().expect("metadata pairs across polls");
+        assert_eq!(m.trigger, "auto");
+        assert_eq!(m.pre_tokens, 50000);
     }
 }

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -34,6 +34,17 @@ pub struct LedgerSnapshot {
     pub seen_percent: f64,
 }
 
+/// Metadata extracted from the `compact_boundary` system record that
+/// precedes the `isCompactSummary` user record in Claude Code logs.
+#[derive(Debug, Clone)]
+pub struct CompactionMetadata {
+    /// "manual", "auto", "warning" — corresponds to the trigger that initiated the compaction.
+    pub trigger: String,
+    pub pre_tokens: u64,
+    pub post_tokens: u64,
+    pub duration_ms: u64,
+}
+
 /// A detected compaction event with summary and pre-compaction state.
 #[derive(Debug, Clone)]
 pub struct CompactionEvent {
@@ -42,13 +53,21 @@ pub struct CompactionEvent {
     pub agent_id: Arc<str>,
     pub summary: String,
     pub ledger_before: LedgerSnapshot,
+    /// Token counts and trigger info from the boundary record. `None` if the
+    /// boundary record was missing or unparseable (older Claude Code versions).
+    pub metadata: Option<CompactionMetadata>,
 }
 
 /// An ordered session event emitted by batch parsing.
 #[derive(Debug, Clone)]
 pub enum SessionEvent {
     ToolCall(AgentToolCall),
-    Compacted { summary: String, timestamp: String, agent_id: Arc<str> },
+    Compacted {
+        summary: String,
+        timestamp: String,
+        agent_id: Arc<str>,
+        metadata: Option<CompactionMetadata>,
+    },
     SessionCleared,
 }
 
@@ -58,6 +77,7 @@ pub struct TailedCompaction {
     pub summary: String,
     pub timestamp: String,
     pub agent_id: Arc<str>,
+    pub metadata: Option<CompactionMetadata>,
 }
 
 /// Output from a single incremental poll of an event tailer.

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -26,6 +26,7 @@ pub struct AgentToolCall {
 }
 
 /// Point-in-time ledger snapshot captured at a compaction boundary.
+#[derive(Debug, Clone)]
 pub struct LedgerSnapshot {
     pub tool_call_count: usize,
     pub files_accessed: BTreeSet<PathBuf>,
@@ -34,6 +35,7 @@ pub struct LedgerSnapshot {
 }
 
 /// A detected compaction event with summary and pre-compaction state.
+#[derive(Debug, Clone)]
 pub struct CompactionEvent {
     pub sequence: u32,
     pub timestamp: String,
@@ -43,15 +45,25 @@ pub struct CompactionEvent {
 }
 
 /// An ordered session event emitted by batch parsing.
+#[derive(Debug, Clone)]
 pub enum SessionEvent {
     ToolCall(AgentToolCall),
     Compacted { summary: String, timestamp: String, agent_id: Arc<str> },
     SessionCleared,
 }
 
+/// A compaction event surfaced by the incremental tailer (no ledger snapshot
+/// here — that's filled in by `App::process_compaction` at receipt time).
+pub struct TailedCompaction {
+    pub summary: String,
+    pub timestamp: String,
+    pub agent_id: Arc<str>,
+}
+
 /// Output from a single incremental poll of an event tailer.
 pub struct TailerOutput {
     pub events: Vec<AgentToolCall>,
+    pub compactions: Vec<TailedCompaction>,
     pub session_cleared: bool,
 }
 

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -22,6 +23,30 @@ pub struct AgentToolCall {
     /// Human-readable label for the agent (e.g. "Explore parser and symbol types").
     /// Falls back to agent_id if no label could be extracted from the session log.
     pub label: Arc<str>,
+}
+
+/// Point-in-time ledger snapshot captured at a compaction boundary.
+pub struct LedgerSnapshot {
+    pub tool_call_count: usize,
+    pub files_accessed: BTreeSet<PathBuf>,
+    pub symbols_seen: usize,
+    pub seen_percent: f64,
+}
+
+/// A detected compaction event with summary and pre-compaction state.
+pub struct CompactionEvent {
+    pub sequence: u32,
+    pub timestamp: String,
+    pub agent_id: Arc<str>,
+    pub summary: String,
+    pub ledger_before: LedgerSnapshot,
+}
+
+/// An ordered session event emitted by batch parsing.
+pub enum SessionEvent {
+    ToolCall(AgentToolCall),
+    Compacted { summary: String, timestamp: String, agent_id: Arc<str> },
+    SessionCleared,
 }
 
 /// Output from a single incremental poll of an event tailer.
@@ -52,7 +77,7 @@ pub trait SessionIngester: Send + Sync {
     /// List all log files belonging to `session_id` within `log_dir`.
     fn session_log_files(&self, log_dir: &Path, session_id: &str) -> Vec<PathBuf>;
     /// Parse all events from a single log file in batch.
-    fn parse_log_file(&self, path: &Path) -> Vec<AgentToolCall>;
+    fn parse_log_file(&self, path: &Path) -> Vec<SessionEvent>;
     /// Create a new incremental event tailer for the given set of files.
     fn new_tailer(&self, files: Vec<PathBuf>) -> Box<dyn EventTailer>;
 
@@ -66,7 +91,7 @@ pub trait SessionIngester: Send + Sync {
     /// Parse all events from a log file, remapping paths when the agent ran in a
     /// worktree whose cwd differs from `project_root`.
     /// Default delegates to `parse_log_file` (no remapping).
-    fn parse_log_file_with_root(&self, path: &Path, project_root: &Path) -> Vec<AgentToolCall> {
+    fn parse_log_file_with_root(&self, path: &Path, project_root: &Path) -> Vec<SessionEvent> {
         let _ = project_root;
         self.parse_log_file(path)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,13 @@ fn main() -> Result<()> {
         let log_files = ingester.session_log_files(log_dir, session_id);
         for log_file in &log_files {
             for event in ingester.parse_log_file_with_root(log_file, &project_path) {
-                app.process_agent_event(event);
+                match event {
+                    ingest::SessionEvent::ToolCall(tc) => app.process_agent_event(tc),
+                    ingest::SessionEvent::Compacted { summary, timestamp, agent_id } => {
+                        app.process_compaction(summary, timestamp, agent_id);
+                    }
+                    ingest::SessionEvent::SessionCleared => app.reset_session(),
+                }
             }
         }
     }
@@ -272,6 +278,9 @@ fn run_tui(
             }
             Ok(AppEvent::AgentEvent(event)) => app.process_agent_event(event),
             Ok(AppEvent::SessionCleared) => app.reset_session(),
+            Ok(AppEvent::Compacted(ev)) => {
+                app.process_compaction(ev.summary, ev.timestamp, ev.agent_id);
+            }
             Ok(AppEvent::Tick) => {
                 session.handle_tick(log_dir, app, serena_mode, project_path);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,8 +217,8 @@ fn main() -> Result<()> {
             for event in ingester.parse_log_file_with_root(log_file, &project_path) {
                 match event {
                     ingest::SessionEvent::ToolCall(tc) => app.process_agent_event(tc),
-                    ingest::SessionEvent::Compacted { summary, timestamp, agent_id } => {
-                        app.process_compaction(summary, timestamp, agent_id);
+                    ingest::SessionEvent::Compacted { summary, timestamp, agent_id, metadata } => {
+                        app.process_compaction(summary, timestamp, agent_id, metadata);
                     }
                     ingest::SessionEvent::SessionCleared => app.reset_session(),
                 }
@@ -279,7 +279,7 @@ fn run_tui(
             Ok(AppEvent::AgentEvent(event)) => app.process_agent_event(event),
             Ok(AppEvent::SessionCleared) => app.reset_session(),
             Ok(AppEvent::Compacted(ev)) => {
-                app.process_compaction(ev.summary, ev.timestamp, ev.agent_id);
+                app.process_compaction(ev.summary, ev.timestamp, ev.agent_id, ev.metadata);
             }
             Ok(AppEvent::Tick) => {
                 session.handle_tick(log_dir, app, serena_mode, project_path);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -148,7 +148,13 @@ impl TuiSession {
                     let new_files = self.ingester.session_log_files(ld, &latest);
                     for log_file in &new_files {
                         for event in self.ingester.parse_log_file_with_root(log_file, project_path) {
-                            app.process_agent_event(event);
+                            match event {
+                                ambits::ingest::SessionEvent::ToolCall(tc) => app.process_agent_event(tc),
+                                ambits::ingest::SessionEvent::Compacted { summary, timestamp, agent_id } => {
+                                    app.process_compaction(summary, timestamp, agent_id);
+                                }
+                                ambits::ingest::SessionEvent::SessionCleared => app.reset_session(),
+                            }
                         }
                     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -150,8 +150,8 @@ impl TuiSession {
                         for event in self.ingester.parse_log_file_with_root(log_file, project_path) {
                             match event {
                                 ambits::ingest::SessionEvent::ToolCall(tc) => app.process_agent_event(tc),
-                                ambits::ingest::SessionEvent::Compacted { summary, timestamp, agent_id } => {
-                                    app.process_compaction(summary, timestamp, agent_id);
+                                ambits::ingest::SessionEvent::Compacted { summary, timestamp, agent_id, metadata } => {
+                                    app.process_compaction(summary, timestamp, agent_id, metadata);
                                 }
                                 ambits::ingest::SessionEvent::SessionCleared => app.reset_session(),
                             }
@@ -179,7 +179,7 @@ impl TuiSession {
                 app.process_agent_event(event);
             }
             for compaction in output.compactions {
-                app.process_compaction(compaction.summary, compaction.timestamp, compaction.agent_id);
+                app.process_compaction(compaction.summary, compaction.timestamp, compaction.agent_id, compaction.metadata);
             }
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -178,6 +178,9 @@ impl TuiSession {
             for event in output.events {
                 app.process_agent_event(event);
             }
+            for compaction in output.compactions {
+                app.process_compaction(compaction.summary, compaction.timestamp, compaction.agent_id);
+            }
         }
 
         // Check if Serena cache files changed.

--- a/src/ui/activity.rs
+++ b/src/ui/activity.rs
@@ -5,8 +5,35 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
 use ambits::app::{App, FocusPanel};
+use ambits::ingest::{AgentToolCall, CompactionEvent};
 
 use super::colors;
+
+/// A single rendered row in the activity feed: either a tool call or a
+/// compaction boundary marker.
+enum FeedEntry<'a> {
+    Tool(&'a AgentToolCall),
+    Compaction(&'a CompactionEvent),
+}
+
+/// Build the merged feed, sorted by timestamp. Tool calls are filtered by
+/// the active agent filter; compactions are always shown.
+fn build_feed<'a>(app: &'a App) -> Vec<FeedEntry<'a>> {
+    let filter = app.agent_filter.as_deref();
+    let mut entries: Vec<(&'a str, FeedEntry<'a>)> = app
+        .activity
+        .iter()
+        .filter(|e| filter.is_none_or(|id| &*e.agent_id == id))
+        .map(|e| (e.timestamp_str.as_str(), FeedEntry::Tool(e)))
+        .chain(
+            app.compaction_history
+                .iter()
+                .map(|c| (c.timestamp.as_str(), FeedEntry::Compaction(c))),
+        )
+        .collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    entries.into_iter().map(|(_, e)| e).collect()
+}
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let border_style = if app.focus == FocusPanel::Activity {
@@ -20,45 +47,44 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL)
         .border_style(border_style);
 
-    // Filter events by agent when a filter is active.
-    let filtered: Vec<&crate::ingest::AgentToolCall> = match app.agent_filter.as_deref() {
-        Some(agent_id) => app.activity.iter().filter(|e| &*e.agent_id == agent_id).collect(),
-        None => app.activity.iter().collect(),
-    };
+    let feed = build_feed(app);
 
     // Window the visible events using the scroll offset.
     let max_lines = area.height.saturating_sub(2) as usize;
-    let total = filtered.len();
+    let total = feed.len();
     // Clamp scroll offset so we can't scroll past the top.
     let max_offset = total.saturating_sub(max_lines);
     let offset = app.activity_scroll_offset.min(max_offset);
     let end = total.saturating_sub(offset);
     let start = end.saturating_sub(max_lines);
-    let visible = &filtered[start..end];
+    let visible = &feed[start..end];
 
+    let width = area.width.saturating_sub(2) as usize;
     let lines: Vec<Line> = visible
         .iter()
-        .map(|event| {
-            let agent_short = if event.agent_id.len() > 8 {
-                &event.agent_id[..8]
-            } else {
-                &event.agent_id
-            };
-
-            Line::from(vec![
-                Span::styled(
-                    format!(" [{}] ", agent_short),
-                    Style::default().fg(colors::ACCENT_MUTED),
-                ),
-                Span::styled(
-                    &event.description,
-                    Style::default().fg(Color::White),
-                ),
-                Span::styled(
-                    format!("  ({})", event.read_depth),
-                    Style::default().fg(Color::DarkGray),
-                ),
-            ])
+        .map(|entry| match entry {
+            FeedEntry::Tool(event) => {
+                let agent_short = if event.agent_id.len() > 8 {
+                    &event.agent_id[..8]
+                } else {
+                    &event.agent_id
+                };
+                Line::from(vec![
+                    Span::styled(
+                        format!(" [{}] ", agent_short),
+                        Style::default().fg(colors::ACCENT_MUTED),
+                    ),
+                    Span::styled(
+                        &event.description,
+                        Style::default().fg(Color::White),
+                    ),
+                    Span::styled(
+                        format!("  ({})", event.read_depth),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ])
+            }
+            FeedEntry::Compaction(c) => compaction_marker_line(c, width),
         })
         .collect();
 
@@ -75,6 +101,25 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     };
 
     f.render_widget(paragraph, area);
+}
+
+/// Render a single-line separator marking a compaction boundary.
+/// Format: ─── compaction #1 · 31.2% seen · 12 files ───────
+fn compaction_marker_line<'a>(c: &'a CompactionEvent, width: usize) -> Line<'a> {
+    let info = format!(
+        " compaction #{} · {:.1}% seen · {} files ",
+        c.sequence,
+        c.ledger_before.seen_percent,
+        c.ledger_before.files_accessed.len(),
+    );
+    let lead = "─".repeat(3);
+    let trail_count = width.saturating_sub(lead.chars().count() + info.chars().count());
+    let trail = "─".repeat(trail_count);
+    Line::from(vec![
+        Span::styled(lead, Style::default().fg(Color::Yellow)),
+        Span::styled(info, Style::default().fg(Color::Yellow)),
+        Span::styled(trail, Style::default().fg(Color::Yellow)),
+    ])
 }
 
 #[cfg(test)]

--- a/src/ui/compaction.rs
+++ b/src/ui/compaction.rs
@@ -1,0 +1,228 @@
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+use ambits::app::App;
+use ambits::ingest::CompactionEvent;
+use ambits::tracking::ReadDepth;
+
+/// Render the compaction diff overlay over `area`. The caller must verify
+/// `app.show_compaction_overlay` and that `compaction_history` is non-empty
+/// before calling.
+pub fn render(f: &mut Frame, app: &App, area: Rect) {
+    let popup_area = centered_rect(area, 80, 70);
+    f.render_widget(Clear, popup_area);
+
+    let Some(ev) = app
+        .compaction_history
+        .get(app.compaction_overlay_index)
+    else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    let title = format!(
+        " Compaction #{} of {} — {} ",
+        ev.sequence,
+        app.compaction_history.len(),
+        ev.timestamp,
+    );
+
+    // Summary block.
+    lines.push(Line::from(Span::styled(
+        "Summary",
+        Style::default().add_modifier(Modifier::BOLD),
+    )));
+    for chunk in wrap_summary(&ev.summary, (popup_area.width as usize).saturating_sub(4)) {
+        lines.push(Line::from(Span::raw(format!("  {chunk}"))));
+    }
+    lines.push(Line::from(""));
+
+    // Before section.
+    lines.push(Line::from(Span::styled(
+        format!(
+            "Before  ({} calls · {} files · {:.1}% seen)",
+            ev.ledger_before.tool_call_count,
+            ev.ledger_before.files_accessed.len(),
+            ev.ledger_before.seen_percent,
+        ),
+        Style::default().add_modifier(Modifier::BOLD),
+    )));
+    if ev.ledger_before.files_accessed.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (no files)",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        for path in ev.ledger_before.files_accessed.iter().take(20) {
+            let path_str = path.to_string_lossy();
+            let depth = file_depth(app, &path_str);
+            lines.push(Line::from(vec![
+                Span::raw(format!("  {path_str:<48} ")),
+                Span::styled(
+                    depth_label(depth).to_string(),
+                    Style::default().fg(depth_color(depth)),
+                ),
+            ]));
+        }
+        if ev.ledger_before.files_accessed.len() > 20 {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "  … ({} more)",
+                    ev.ledger_before.files_accessed.len() - 20,
+                ),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+    lines.push(Line::from(""));
+
+    // After section: files present in the current ledger but absent from
+    // the pre-compaction snapshot.
+    let after_files = files_after_compaction(app, ev);
+    lines.push(Line::from(Span::styled(
+        format!("After  ({} files since compaction)", after_files.len()),
+        Style::default().add_modifier(Modifier::BOLD),
+    )));
+    if after_files.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (no new files since compaction)",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        for (path, depth) in after_files.iter().take(20) {
+            lines.push(Line::from(vec![
+                Span::raw(format!("  {path:<48} ")),
+                Span::styled(
+                    depth_label(*depth).to_string(),
+                    Style::default().fg(depth_color(*depth)),
+                ),
+            ]));
+        }
+        if after_files.len() > 20 {
+            lines.push(Line::from(Span::styled(
+                format!("  … ({} more)", after_files.len() - 20),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  [ / ] step through compactions   C close",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    f.render_widget(paragraph, popup_area);
+}
+
+/// Compute the current max read depth across all symbols in the file matching `rel_path`.
+fn file_depth(app: &App, rel_path: &str) -> ReadDepth {
+    let Some(file) = app
+        .project_tree
+        .files
+        .iter()
+        .find(|f| f.file_path.to_string_lossy() == rel_path)
+    else {
+        return ReadDepth::Unseen;
+    };
+    let mut best = ReadDepth::Unseen;
+    walk_symbols(&file.symbols, &app.ledger, &mut best);
+    best
+}
+
+fn walk_symbols(
+    symbols: &[ambits::symbols::SymbolNode],
+    ledger: &ambits::tracking::ContextLedger,
+    best: &mut ReadDepth,
+) {
+    for sym in symbols {
+        let d = ledger.depth_of(&sym.id);
+        if d > *best {
+            *best = d;
+        }
+        walk_symbols(&sym.children, ledger, best);
+    }
+}
+
+/// Files that have been read since the compaction boundary — files present in
+/// the current ledger but not in the pre-compaction snapshot.
+fn files_after_compaction(app: &App, ev: &CompactionEvent) -> Vec<(String, ReadDepth)> {
+    let mut out: Vec<(String, ReadDepth)> = Vec::new();
+    for file in &app.project_tree.files {
+        let path_str = file.file_path.to_string_lossy().into_owned();
+        let mut best = ReadDepth::Unseen;
+        walk_symbols(&file.symbols, &app.ledger, &mut best);
+        if best.is_seen()
+            && !ev
+                .ledger_before
+                .files_accessed
+                .iter()
+                .any(|p| p.to_string_lossy() == path_str)
+        {
+            out.push((path_str, best));
+        }
+    }
+    out
+}
+
+fn depth_label(d: ReadDepth) -> &'static str {
+    match d {
+        ReadDepth::Unseen => "Unseen",
+        ReadDepth::Stale => "Stale",
+        ReadDepth::NameOnly => "NameOnly",
+        ReadDepth::Overview => "Overview",
+        ReadDepth::Signature => "Signature",
+        ReadDepth::FullBody => "FullBody",
+    }
+}
+
+fn depth_color(d: ReadDepth) -> Color {
+    match d {
+        ReadDepth::Unseen => Color::DarkGray,
+        ReadDepth::Stale => Color::Red,
+        ReadDepth::NameOnly => Color::Gray,
+        ReadDepth::Overview => Color::Cyan,
+        ReadDepth::Signature => Color::Blue,
+        ReadDepth::FullBody => Color::Green,
+    }
+}
+
+fn wrap_summary(text: &str, width: usize) -> Vec<String> {
+    let width = width.max(20);
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.len() + 1 + word.len() > width {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+        } else {
+            current.push(' ');
+            current.push_str(word);
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
+/// Compute a centered subrect taking `percent_x` × `percent_y` of `area`.
+fn centered_rect(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
+    let w = area.width * percent_x / 100;
+    let h = area.height * percent_y / 100;
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect { x, y, width: w, height: h }
+}

--- a/src/ui/compaction.rs
+++ b/src/ui/compaction.rs
@@ -23,12 +23,23 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let mut lines: Vec<Line> = Vec::new();
-    let title = format!(
-        " Compaction #{} of {} — {} ",
-        ev.sequence,
-        app.compaction_history.len(),
-        ev.timestamp,
-    );
+    let title = match &ev.metadata {
+        Some(m) => format!(
+            " Compaction #{} of {} — {} · {} → {} tok · {} ",
+            ev.sequence,
+            app.compaction_history.len(),
+            ev.timestamp,
+            format_tokens(m.pre_tokens),
+            format_tokens(m.post_tokens),
+            m.trigger,
+        ),
+        None => format!(
+            " Compaction #{} of {} — {} ",
+            ev.sequence,
+            app.compaction_history.len(),
+            ev.timestamp,
+        ),
+    };
 
     // Summary block.
     lines.push(Line::from(Span::styled(
@@ -170,6 +181,17 @@ fn files_after_compaction(app: &App, ev: &CompactionEvent) -> Vec<(String, ReadD
         }
     }
     out
+}
+
+/// Format a token count in compact form: `1234` → `1.2k`, `1234567` → `1.2M`.
+fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
 }
 
 fn depth_label(d: ReadDepth) -> &'static str {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod colors;
 pub mod tree_view;
 pub mod stats;
 pub mod activity;
+pub mod compaction;
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout};
@@ -30,6 +31,10 @@ pub fn render(f: &mut Frame, app: &App) {
     stats::render(f, app, top[1]);
     activity::render(f, app, outer[1]);
     render_status_bar(f, app, outer[2]);
+
+    if app.show_compaction_overlay && !app.compaction_history.is_empty() {
+        compaction::render(f, app, f.area());
+    }
 }
 
 fn render_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
@@ -63,6 +68,15 @@ fn render_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
             Span::styled("[tab]", Style::default().fg(Color::DarkGray)),
             Span::raw("focus "),
         ];
+
+        if !app.compaction_history.is_empty() {
+            spans.push(Span::styled("[C]", Style::default().fg(Color::Yellow)));
+            spans.push(Span::raw(if app.show_compaction_overlay {
+                "close "
+            } else {
+                "ompact "
+            }));
+        }
 
         // Show current agent filter
         if let Some(ref agent_id) = app.agent_filter {

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -94,6 +94,28 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         ]));
     }
 
+    // Compactions summary.
+    if let Some(last) = app.compaction_history.last() {
+        lines.push(Line::from(vec![
+            Span::raw("  Compactions: "),
+            Span::styled(
+                format!("{}", app.compaction_history.len()),
+                Style::default().fg(Color::White),
+            ),
+        ]));
+        lines.push(Line::from(vec![
+            Span::raw("  Last: "),
+            Span::styled(
+                last.timestamp.clone(),
+                Style::default().fg(colors::ACCENT_MUTED),
+            ),
+            Span::styled(
+                format!("  {:.1}% seen before", last.ledger_before.seen_percent),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+
     // Agents section.
     if !app.agents_seen.is_empty() {
         lines.push(Line::from(""));

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -114,6 +114,20 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(Color::DarkGray),
             ),
         ]));
+        if let Some(m) = &last.metadata {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    format!(
+                        "{} → {} tok · {}",
+                        format_tokens(m.pre_tokens),
+                        format_tokens(m.post_tokens),
+                        m.trigger,
+                    ),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+        }
     }
 
     // Agents section.
@@ -246,6 +260,17 @@ fn short_id(id: &str) -> String {
         id[..12].to_string()
     } else {
         id.to_string()
+    }
+}
+
+/// Format a token count in compact form: `1234` → `1.2k`, `1234567` → `1.2M`.
+fn format_tokens(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
     }
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -9,11 +9,23 @@ use ambits::app::App;
 use ambits::coverage::{CoverageFormatter, CoverageReport, JsonFormatter, TextFormatter};
 use ambits::ingest::claude::parse_log_file;
 use ambits::ingest::tool_config::ToolMappingConfig;
-use ambits::ingest::AgentToolCall;
+use ambits::ingest::{AgentToolCall, SessionEvent};
 use ambits::symbols::merkle::content_hash;
 use ambits::symbols::{FileSymbols, ProjectTree, SymbolCategory, SymbolNode};
 use ambits::tracking::{ContextLedger, ReadDepth};
 use tempfile::NamedTempFile;
+
+/// Drain `SessionEvent::ToolCall` events into a flat `Vec<AgentToolCall>` so
+/// existing assertions that iterate raw tool calls keep working.
+fn tool_calls(events: Vec<SessionEvent>) -> Vec<AgentToolCall> {
+    events
+        .into_iter()
+        .filter_map(|e| match e {
+            SessionEvent::ToolCall(tc) => Some(tc),
+            _ => None,
+        })
+        .collect()
+}
 
 fn builtin_cfg() -> ToolMappingConfig {
     ToolMappingConfig::builtin().expect("built-in config must parse")
@@ -110,7 +122,7 @@ fn full_pipeline_read() {
 
     // Parse a Read event for file_a (absolute path gets normalized).
     let tmp = write_jsonl(&[jsonl_read("/test/project/mock/file_a.rs")]);
-    let events = parse_log_file(tmp.path(), &builtin_cfg());
+    let events = tool_calls(parse_log_file(tmp.path(), &builtin_cfg()));
     assert_eq!(events.len(), 1);
 
     for event in events {
@@ -137,7 +149,7 @@ fn targeted_symbol_partial() {
     let mut app = make_app(files);
 
     let tmp = write_jsonl(&[jsonl_find_symbol("mock/f.rs", "beta", true)]);
-    let events = parse_log_file(tmp.path(), &builtin_cfg());
+    let events = tool_calls(parse_log_file(tmp.path(), &builtin_cfg()));
     for event in events {
         app.process_agent_event(event);
     }
@@ -166,7 +178,7 @@ fn depth_upgrade_invariant() {
         jsonl_grep("pattern"),                      // NameOnly again — must NOT downgrade
     ];
     let tmp = write_jsonl(&lines);
-    let events = parse_log_file(tmp.path(), &builtin_cfg());
+    let events = tool_calls(parse_log_file(tmp.path(), &builtin_cfg()));
     for event in events {
         app.process_agent_event(event);
     }
@@ -186,7 +198,7 @@ fn multi_agent_session() {
         jsonl_read("/test/project/mock/f.rs"),
         jsonl_read("/test/project/mock/f.rs"),
     ]);
-    let mut events: Vec<AgentToolCall> = parse_log_file(tmp.path(), &builtin_cfg());
+    let mut events: Vec<AgentToolCall> = tool_calls(parse_log_file(tmp.path(), &builtin_cfg()));
     events[0].agent_id = "agent-alpha".into();
     events[1].agent_id = "agent-beta".into();
 
@@ -307,7 +319,7 @@ fn json_formatter_structure() {
     let v: serde_json::Value =
         serde_json::from_str(output.trim()).expect("output must be valid JSON");
 
-    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["schema_version"], 2);
     assert_eq!(v["session_id"], "test-session-456");
     assert!(v["agent_id"].is_null());
     assert_eq!(v["totals"]["symbols"], 1);
@@ -354,7 +366,7 @@ fn json_formatter_empty_project() {
     let output = JsonFormatter.format(&report);
     let v: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
 
-    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["schema_version"], 2);
     assert_eq!(v["totals"]["symbols"], 0);
     assert_eq!(v["totals"]["seen"], 0);
     assert_eq!(v["totals"]["full"], 0);

--- a/tests/integration_tool_config.rs
+++ b/tests/integration_tool_config.rs
@@ -459,6 +459,12 @@ fn parse_log_file_all_tool_stanzas() {
     }
 
     let events = parse_log_file(tmp.path(), &cfg);
-    assert_eq!(events.len(), 15, "expected 15 events, got {}: {:?}", events.len(),
-        events.iter().map(|e| &e.tool_name).collect::<Vec<_>>());
+    let tool_names: Vec<&str> = events
+        .iter()
+        .filter_map(|e| match e {
+            ambits::ingest::SessionEvent::ToolCall(tc) => Some(tc.tool_name.as_ref()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(tool_names.len(), 15, "expected 15 events, got {}: {:?}", tool_names.len(), tool_names);
 }


### PR DESCRIPTION
Why
Forced compactions in Claude Code v2.1.132 were silently dropped — the TUI stats panel, activity feed, overlay, and `--coverage` output all showed no compaction info. The spike doc had assumed compactions arrived as a `type:"compaction"` content block, but the real shape is two records: a `type:"system" subtype:"compact_boundary"` marker (with token/trigger metadata) followed by a `type:"user" isCompactSummary:true` record carrying the summary text. The parser never matched real data, and the live ledger continued reporting pre-compaction reads as still-in-context — over-reporting coverage.

### What changed
Three commits, each independently reviewable:

**`c87c6da` — detect real compaction records.** Parser recognizes `isCompactSummary:true` user records (taking precedence over the `/clear` heuristic) and plumbs Compacted events through `TailerOutput`. Stats panel, activity feed, overlay, and coverage report (text + JSON, schema v2) all surface compactions.

**`a83ffe0` — surface `compact_boundary` token metadata.** Pairs the boundary record with the following summary so we can show `pre → post tok · trigger · duration`. Buffering lives on `LogTailer` so a boundary that arrives alone in one poll still pairs with the summary in a later poll. JSON `metadata` field is optional and additive (schema v2 unchanged).

**`eb18adc` — clear live ledger on compaction.** Compaction destroys most verbatim file content; treat it like `/clear` for the ledger. `App::process_compaction` now snapshots the pre-state into `compaction_history`, then wipes `ledger` and `compaction_call_count`. `coverage::run_report` mirrors this. `compaction_history`, activity, agents, and session metadata are preserved.

To keep cross-file event ordering sane, `session_log_files()` now returns the main session JSONL last so subagent reads accumulate before any compaction in the main file wipes the ledger.

### Known limitation
A subagent finishing *after* the main session's compaction will still have its post-compaction reads erroneously wiped. The main-last ordering covers the typical case; a full cross-file timestamp merge is deferred and documented in `session_log_files()`.

### Verification
End-to-end against a real session JSONL with a manual compaction:
- Coverage: `Tokens: 195684 → 6416 (-96.7%) · trigger: manual · 64.7s`
- JSON includes `metadata: { trigger, pre_tokens, post_tokens, duration_ms }` on each compaction entry
- Live totals reflect post-compaction work only (293 symbols seen vs. 376 captured in `state_before`)
- 323 tests pass (261 lib + 14 main bin + 11 e2e + 37 integration)