### PR TITLE
Perf/merkle ascii fastpath

### DIFF
--- a/src/symbols/merkle.rs
+++ b/src/symbols/merkle.rs
@@ -82,6 +82,36 @@ fn normalize_source(source: &str) -> String {
 /// vocabulary. It will be most accurate for English-identifier code (Rust, Python,
 /// TypeScript) and less accurate for heavily symbolic code (e.g. APL, dense regex).
 pub fn estimate_tokens(source: &str) -> usize {
+    if source.is_ascii() {
+        return estimate_tokens_ascii(source.as_bytes());
+    }
+    estimate_tokens_unicode(source)
+}
+
+#[inline]
+fn estimate_tokens_ascii(bytes: &[u8]) -> usize {
+    let mut count = 0usize;
+    let mut word_len = 0usize;
+    for &b in bytes {
+        if b.is_ascii_alphanumeric() || b == b'_' {
+            word_len += 1;
+        } else {
+            if word_len > 0 {
+                count += word_len.div_ceil(4);
+                word_len = 0;
+            }
+            if !is_unicode_ws_ascii(b) {
+                count += 1;
+            }
+        }
+    }
+    if word_len > 0 {
+        count += word_len.div_ceil(4);
+    }
+    count
+}
+
+fn estimate_tokens_unicode(source: &str) -> usize {
     let mut count = 0usize;
     let mut word_len = 0usize;
 
@@ -102,6 +132,15 @@ pub fn estimate_tokens(source: &str) -> usize {
         count += word_len.div_ceil(4);
     }
     count
+}
+
+/// ASCII subset of Unicode's `White_Space` property: matches `char::is_whitespace()`
+/// for any ASCII byte. `u8::is_ascii_whitespace()` excludes U+000B (vertical tab),
+/// which Unicode treats as whitespace — we include it so the fast path is bit-for-bit
+/// equivalent to the Unicode path for ASCII input.
+#[inline]
+fn is_unicode_ws_ascii(b: u8) -> bool {
+    matches!(b, b'\t' | b'\n' | 0x0B | 0x0C | b'\r' | b' ')
 }
 
 #[cfg(test)]
@@ -134,6 +173,27 @@ mod tests {
         let h1 = content_hash("fn foo() {}");
         let h2 = content_hash("fn bar() {}");
         assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn ascii_and_unicode_paths_agree_on_ascii_input() {
+        // The fast path takes the ASCII branch; we manually compare against the
+        // Unicode fallback for the same input.
+        let samples = [
+            "",
+            "fn foo() {}",
+            "calculate_result",
+            "let x = (a + b) * c;",
+            "  \n\t  ",
+            "a\x0Bb",  // includes vertical tab — Unicode whitespace but not ASCII whitespace
+        ];
+        for s in samples {
+            assert_eq!(
+                estimate_tokens_ascii(s.as_bytes()),
+                estimate_tokens_unicode(s),
+                "estimate_tokens disagreement on {s:?}",
+            );
+        }
     }
 
     #[test]

--- a/src/symbols/merkle.rs
+++ b/src/symbols/merkle.rs
@@ -4,11 +4,51 @@ use super::SymbolNode;
 
 /// Compute content hash from the raw source text of a symbol.
 /// Normalizes whitespace to make hashing resilient to formatting changes.
+///
+/// For ASCII input — virtually all source code — we stream normalized bytes
+/// directly into the SHA-256 hasher through a stack buffer, skipping the
+/// intermediate `String` allocation and Unicode-aware classification used by
+/// the general fallback. Both paths feed bit-for-bit identical byte sequences
+/// to the hasher, so hash values are unchanged.
 pub fn content_hash(source: &str) -> [u8; 32] {
-    let normalized = normalize_source(source);
     let mut hasher = Sha256::new();
-    hasher.update(normalized.as_bytes());
+    if source.is_ascii() {
+        hash_normalized_ascii(source.trim().as_bytes(), &mut hasher);
+    } else {
+        let normalized = normalize_source(source);
+        hasher.update(normalized.as_bytes());
+    }
     hasher.finalize().into()
+}
+
+/// Stream `bytes` into `hasher` after collapsing runs of ASCII whitespace into a
+/// single space, matching `normalize_source` byte-for-byte. Caller must pre-trim.
+#[inline]
+fn hash_normalized_ascii(bytes: &[u8], hasher: &mut Sha256) {
+    let mut buf = [0u8; 256];
+    let mut len = 0;
+    let mut prev_was_space = false;
+    for &b in bytes {
+        let push = if is_unicode_ws_ascii(b) {
+            if prev_was_space {
+                continue;
+            }
+            prev_was_space = true;
+            b' '
+        } else {
+            prev_was_space = false;
+            b
+        };
+        buf[len] = push;
+        len += 1;
+        if len == buf.len() {
+            hasher.update(buf);
+            len = 0;
+        }
+    }
+    if len > 0 {
+        hasher.update(&buf[..len]);
+    }
 }
 
 /// Compute the Merkle hash for a symbol node.
@@ -173,6 +213,36 @@ mod tests {
         let h1 = content_hash("fn foo() {}");
         let h2 = content_hash("fn bar() {}");
         assert_ne!(h1, h2);
+    }
+
+    /// Reference implementation: hash the output of the existing Unicode
+    /// `normalize_source` path. Used to assert the ASCII fast path is
+    /// bit-for-bit equivalent.
+    fn content_hash_via_unicode(source: &str) -> [u8; 32] {
+        let normalized = normalize_source(source);
+        let mut hasher = Sha256::new();
+        hasher.update(normalized.as_bytes());
+        hasher.finalize().into()
+    }
+
+    #[test]
+    fn content_hash_ascii_path_matches_unicode_path() {
+        let samples = [
+            "",
+            "fn foo() {}",
+            "fn  foo()  {  }",
+            "   \n\t  fn bar() {}\n\n",
+            "let x = (a + b) * c;\nlet y = x * 2;",
+            "a\x0Bb",  // vertical tab — Unicode whitespace, not ASCII whitespace
+            include_str!("merkle.rs"),  // larger ASCII payload: this very file
+        ];
+        for s in samples {
+            assert_eq!(
+                content_hash(s),
+                content_hash_via_unicode(s),
+                "content_hash disagreement on {s:?}",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
ASCII fast paths in symbol hashing

### Why
CI bench `merkle_hash/bench_estimate_tokens/large` was failing at 10,290 ns vs a 10,000 ns budget. Investigation found two functions on the parse hot path were paying full Unicode cost on what is virtually always ASCII source code:

- `estimate_tokens` walked `source.chars()` and called `char::is_alphanumeric()` / `char::is_whitespace()` per character — both do Unicode general-category property lookups.
- `content_hash` allocated a `String` via `normalize_source` solely as a buffer between Unicode-aware whitespace collapsing and SHA-256, then dropped it.

### What changed
Two commits, one function each:

**`a1661f8` — `estimate_tokens` ASCII fast path.** Splits into `estimate_tokens_ascii(&[u8])` (byte-level loop, `is_ascii_alphanumeric` + range-check whitespace) and `estimate_tokens_unicode(&str)` (the original body, kept as fallback). `str::is_ascii()` dispatches; it's a single SIMD-vectorized pass, typically cheaper than one `chars()` iteration on its own.

**`267ffae` — `content_hash` no-alloc streaming.** Streams normalized bytes directly into the SHA-256 hasher through a 256-byte stack buffer for ASCII input. No allocation, no UTF-8 decode, no Unicode classification. Unicode path preserved verbatim for non-ASCII input.

A helper `is_unicode_ws_ascii` matches `char::is_whitespace()` exactly on ASCII bytes (including U+000B, which `u8::is_ascii_whitespace()` excludes) so the two paths are bit-for-bit equivalent.

### Hash compatibility
`content_hash` values are **unchanged**. A new test feeds representative ASCII inputs — including this source file itself as a non-trivial payload — through both paths and asserts byte-for-byte hash equality. Anything that has persisted or cached a `content_hash` will continue to match.

### Verification
- 245 lib tests + 37 integration tests pass.
- Local bench (M-series Mac, `DIVAN_SAMPLE_COUNT=20`):
  - `estimate_tokens/large`: 8,416 ns median (was 10,290 ns in CI) — ~16% under budget.
  - `estimate_tokens/medium`: 3,083 ns median (was 3,721 ns in CI / 1.34× tight).
- No threshold bump included. If CI hardware is slow enough that `large` still lands borderline, a follow-up threshold relaxation is a one-line change.